### PR TITLE
fixes: reconstruction for station-station, GTFS trips with first dep>24:00, lb init

### DIFF
--- a/include/nigiri/routing/raptor.h
+++ b/include/nigiri/routing/raptor.h
@@ -39,6 +39,8 @@ private:
   static constexpr auto const kFwd = (SearchDir == direction::kForward);
   static constexpr auto const kBwd = (SearchDir == direction::kBackward);
 
+  bool start_dest_overlap() const;
+
   bool is_ontrip() const;
 
   bool is_better(auto a, auto b);

--- a/src/loader/build_footpaths.cc
+++ b/src/loader/build_footpaths.cc
@@ -30,7 +30,11 @@ struct fmt::formatter<nigiri::matrix<T>> {
       -> decltype(ctx.out()) {
     for (auto i = 0U; i != m.n_rows_; ++i) {
       for (auto j = 0U; j != m.n_columns_; ++j) {
-        fmt::format_to(ctx.out(), "{:2} ", m[i][j]);
+        if (m[i][j] == std::numeric_limits<T>::max()) {
+          fmt::format_to(ctx.out(), "** ");
+        } else {
+          fmt::format_to(ctx.out(), "{:2} ", m[i][j]);
+        }
       }
       fmt::format_to(ctx.out(), "\n");
     }
@@ -179,7 +183,7 @@ void process_component(timetable& tt,
   };
 
   if constexpr (kTracing) {
-    auto const id = std::string_view{"de:12054:900230999::4"};
+    auto const id = std::string_view{"de:11000:900160002:1:50"};
     auto const needle =
         std::find_if(begin(tt.locations_.ids_), end(tt.locations_.ids_),
                      [&](auto&& x) { return x.view() == id; });
@@ -279,16 +283,16 @@ next:
     }
   }
 
-  print_dbg("STATIONS:\n");
+  print_dbg("NIGIRI STATIONS:\n");
   for (auto i = 0U; i != size; ++i) {
     print_dbg("{} = {} \n", i, location{tt, location_idx_t{(lb + i)->second}});
   }
 
-  print_dbg("MAT BEFORE {}\n", mat);
+  print_dbg("NIGIRI MAT BEFORE\n{}\n", mat);
 
   floyd_warshall(mat);
 
-  print_dbg("MAT AFTER\n{}", mat);
+  print_dbg("NIGIRI MAT AFTER\n{}", mat);
 
   print_dbg("\n\nOUTPUT\n");
   for (auto i = 0U; i < size; ++i) {

--- a/src/loader/gtfs/stop.cc
+++ b/src/loader/gtfs/stop.cc
@@ -70,6 +70,13 @@ struct stop {
         ++it;
       }
     }
+
+    for (auto const& d : done) {
+      for (auto const& c : d->children_) {
+        done.insert(c);
+      }
+    }
+
     return done;
   }
 

--- a/src/routing/dijkstra.cc
+++ b/src/routing/dijkstra.cc
@@ -45,10 +45,16 @@ void dijkstra(timetable const& tt,
 
   std::map<location_idx_t, duration_t> min;
   for (auto const& start : q.destinations_.front()) {
-    auto const p = tt.locations_.parents_[start.target_];
-    auto const l = (p == location_idx_t::invalid()) ? start.target_ : p;
-    auto& m = utl::get_or_create(min, l, [&]() { return dists[to_idx(l)]; });
-    m = std::min(start.duration_, m);
+    for_each_meta(
+        tt, q.dest_match_mode_, start.target_, [&](location_idx_t const x) {
+          // Map to parent
+          // because the lower bound graph operates only on parents.
+          auto const p = tt.locations_.parents_[x];
+          auto const l = (p == location_idx_t::invalid()) ? x : p;
+          auto& m =
+              utl::get_or_create(min, l, [&]() { return dists[to_idx(l)]; });
+          m = std::min(start.duration_, m);
+        });
   }
 
   dial<label, kMaxTravelTime.count(), get_bucket> pq;


### PR DESCRIPTION
- fix reconstruction:
  - checked if first leg start is meta to start station
  - then required that start station is meta to leg start
  - thereby assumed symmetric equivalence relation, which is not the case
  - fixed check to be consistent
- in GTFS some services have a start time of >24:00 which implies they operate the next day
  - when checking if a service is active the service operating time interval (in days) contained also the first day (before 24:00) - but here, the service is not active and should therefore not be loaded (to be consistent with MOTIS)
- lower bound initialization was not considering equivalent stations, now it does