### PR TITLE
use linear lower bound instead of std::lower_bound

### DIFF
--- a/include/nigiri/common/linear_lower_bound.h
+++ b/include/nigiri/common/linear_lower_bound.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace nigiri {
+
+template <typename It, typename End, typename Key, typename Cmp>
+It linear_lb(It&& it, End&& end, Key&& key, Cmp&& cmp) {
+  for (; it != end; ++it) {
+    if (!cmp(key, *it)) {
+      return it;
+    }
+  }
+  return end;
+}
+
+}  // namespace nigiri

--- a/include/nigiri/routing/raptor/raptor.h
+++ b/include/nigiri/routing/raptor/raptor.h
@@ -2,6 +2,7 @@
 
 #include "utl/enumerate.h"
 
+#include "nigiri/common/linear_lower_bound.h"
 #include "nigiri/routing/journey.h"
 #include "nigiri/routing/limits.h"
 #include "nigiri/routing/pareto_set.h"
@@ -434,7 +435,7 @@ private:
         r, stop_idx, kFwd ? event_type::kDep : event_type::kArr);
 
     auto const seek_first_day = [&, mam_at_stop = mam_at_stop]() {
-      return std::lower_bound(
+      return linear_lb(
           get_begin_it(event_times), get_end_it(event_times), mam_at_stop,
           [&](auto&& a, auto&& b) { return is_better(a % 1440, b % 1440); });
     };
@@ -478,7 +479,7 @@ private:
         }
 
         auto const t = tt_.route_transport_ranges_[r][t_offset];
-        if (day == day_at_stop && !is_better_or_eq(mam_at_stop, ev_mam)) {
+        if (i == 0U && !is_better_or_eq(mam_at_stop, ev_mam)) {
           trace(
               "┊ │k={}      => transport={}, name={}, dbg={}, day={}/{}, "
               "best_mam={}, "


### PR DESCRIPTION
| Version | Average | q99 | q90 | q80 | q50 |
| ----------------- | ------------- |------------- |------------- |------------- |------------- |
| Binary Search | 830 ms  | 2,661 ms | 1,544 ms  |  1,218 ms   | 676 ms |
| No Seek          | 815 ms  | 2,645 ms | 1,506 ms  |   1,197 ms  | 659 ms |
| Linear Seek    | 793 ms   | 2,478 ms | 1,484 ms |   1,150  ms | 639 ms |


```ini
modules=nigiri
modules=intermodal
modules=osrm

mode=batch
num_threads=12
dataset.no_schedule=true
intermodal.router=nigiri
osrm.profiles=/home/felix/code/motis/deps/osrm-backend/profiles/foot.lua

[import]
paths=schedule-nl:input/schedule/nl
paths=schedule-delfi:input/schedule/delfi
paths=schedule-swiss:input/schedule/swiss
paths=osm:input/osm.pbf

[nigiri]
geo_lookup=true
first_day=2023-05-16
num_days=14
```