### PR TITLE
Provide an ABI to enable projects written in other languages to use nigiri as a lib

### DIFF
--- a/include/nigiri/abi.h
+++ b/include/nigiri/abi.h
@@ -11,7 +11,7 @@ typedef struct nigiri_timetable nigiri_timetable_t;
 struct nigiri_transport {
   // bitfield_idx_t bitfield_idx_;
   uint32_t route_idx;
-  uint32_t n_event_mams;
+  uint16_t n_event_mams;
   int16_t* event_mams;
   const char* name;
 };
@@ -22,15 +22,15 @@ struct nigiri_stop {
   char* name;
   double lon;
   double lat;
-  uint32_t transfer_time;
-  int32_t parent;
+  uint16_t transfer_time;
+  uint32_t parent;
 };
 typedef struct nigiri_stop nigiri_stop_t;
 
 struct nigiri_route {
-  uint32_t n_stops;
+  uint16_t n_stops;
   uint32_t* stops;
-  uint32_t clasz;
+  uint16_t clasz;
 };
 typedef struct nigiri_route nigiri_route_t;
 

--- a/include/nigiri/abi.h
+++ b/include/nigiri/abi.h
@@ -30,9 +30,9 @@ struct nigiri_location {
 typedef struct nigiri_location nigiri_location_t;
 
 struct nigiri_route_stop {
-  uint32_t location_idx : 30;
-  bool in_allowed : 1;
-  bool out_allowed : 1;
+  unsigned int location_idx : 30;
+  unsigned int in_allowed : 1;
+  unsigned int out_allowed : 1;
 };
 typedef struct nigiri_route_stop nigiri_route_stop_t;
 
@@ -75,7 +75,9 @@ void nigiri_destroy_location(const nigiri_location_t* location);
 
 void nigiri_update_with_rt(const nigiri_timetable_t* t,
                            const char* gtfsrt_pb_path,
-                           void (*callback)(nigiri_event_change_t));
+                           void (*callback)(nigiri_event_change_t,
+                                            void* context),
+                           void* context);
 
 #ifdef __cplusplus
 }

--- a/include/nigiri/abi.h
+++ b/include/nigiri/abi.h
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,11 +34,22 @@ struct nigiri_route {
 };
 typedef struct nigiri_route nigiri_route_t;
 
+struct nigiri_event_change {
+    uint32_t transport_idx;
+    uint16_t day;
+    uint32_t stop_idx;
+    bool is_departure;
+    int16_t delay;
+    bool cancelled;
+};
+typedef struct nigiri_event_change nigiri_event_change_t;
+
 
 nigiri_timetable_t *nigiri_load(const char* path, int64_t from_ts, int64_t to_ts);
 void nigiri_destroy(const nigiri_timetable_t *t);
 uint32_t nigiri_get_transport_count(const nigiri_timetable_t *t);
 nigiri_transport_t *nigiri_get_transport(const nigiri_timetable_t *t, uint32_t idx);
+bool nigiri_is_transport_active(const nigiri_transport_t *transport, uint16_t day);
 void nigiri_destroy_transport(const nigiri_transport_t *transport);
 nigiri_route_t *nigiri_get_route(const nigiri_timetable_t *t, uint32_t idx);
 void nigiri_destroy_route(const nigiri_route_t *route);
@@ -45,7 +57,7 @@ uint32_t nigiri_get_stop_count(const nigiri_timetable_t *t);
 nigiri_stop_t *nigiri_get_stop(const nigiri_timetable_t *t, uint32_t idx);
 void nigiri_destroy_stop(const nigiri_stop_t *stop);
 
-void update_with_rt(nigiri_timetable_t *t);
+void nigiri_update_with_rt(const nigiri_timetable_t *t, const char* gtfsrt_pb_path, void (*callback)(nigiri_event_change_t));
 
 #ifdef __cplusplus
 }

--- a/include/nigiri/abi.h
+++ b/include/nigiri/abi.h
@@ -17,7 +17,7 @@ struct nigiri_transport {
 };
 typedef struct nigiri_transport nigiri_transport_t;
 
-struct nigiri_stop {
+struct nigiri_location {
   char* id;
   char* name;
   double lon;
@@ -25,11 +25,18 @@ struct nigiri_stop {
   uint16_t transfer_time;
   uint32_t parent;
 };
-typedef struct nigiri_stop nigiri_stop_t;
+typedef struct nigiri_location nigiri_location_t;
+
+struct nigiri_route_stop {
+    uint32_t location_idx: 30;
+    bool in_allowed: 1;
+    bool out_allowed: 1;
+};
+typedef struct nigiri_route_stop nigiri_route_stop_t;
 
 struct nigiri_route {
   uint16_t n_stops;
-  uint32_t* stops;
+  nigiri_route_stop_t* stops;
   uint16_t clasz;
 };
 typedef struct nigiri_route nigiri_route_t;
@@ -59,9 +66,9 @@ bool nigiri_is_transport_active(const nigiri_timetable_t* t,
                                 uint16_t day_idx);
 nigiri_route_t* nigiri_get_route(const nigiri_timetable_t* t, uint32_t idx);
 void nigiri_destroy_route(const nigiri_route_t* route);
-uint32_t nigiri_get_stop_count(const nigiri_timetable_t* t);
-nigiri_stop_t* nigiri_get_stop(const nigiri_timetable_t* t, uint32_t idx);
-void nigiri_destroy_stop(const nigiri_stop_t* stop);
+uint32_t nigiri_get_location_count(const nigiri_timetable_t* t);
+nigiri_location_t* nigiri_get_location(const nigiri_timetable_t* t, uint32_t idx);
+void nigiri_destroy_location(const nigiri_location_t* location);
 
 void nigiri_update_with_rt(const nigiri_timetable_t* t,
                            const char* gtfsrt_pb_path,

--- a/include/nigiri/abi.h
+++ b/include/nigiri/abi.h
@@ -1,0 +1,51 @@
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct nigiri_timetable;
+typedef struct nigiri_timetable nigiri_timetable_t;
+
+struct nigiri_transport {
+    //bitfield_idx_t bitfield_idx_;
+    uint32_t route_idx;
+    uint32_t n_event_mams;
+    int16_t *event_mams;
+    const char* name;
+};
+typedef struct nigiri_transport nigiri_transport_t;
+
+struct nigiri_stop {
+    char *id;
+    char *name;
+    double lon;
+    double lat;
+    uint32_t transfer_time;
+    int32_t parent;
+};
+typedef struct nigiri_stop nigiri_stop_t;
+
+struct nigiri_route {
+    uint32_t n_stops;
+    uint32_t *stops;
+    uint32_t clasz;
+};
+typedef struct nigiri_route nigiri_route_t;
+
+
+nigiri_timetable_t *nigiri_load(const char* path, int64_t from_ts, int64_t to_ts);
+void nigiri_destroy(const nigiri_timetable_t *t);
+uint32_t nigiri_get_transport_count(const nigiri_timetable_t *t);
+nigiri_transport_t *nigiri_get_transport(const nigiri_timetable_t *t, uint32_t idx);
+void nigiri_destroy_transport(const nigiri_transport_t *transport);
+nigiri_route_t *nigiri_get_route(const nigiri_timetable_t *t, uint32_t idx);
+void nigiri_destroy_route(const nigiri_route_t *route);
+nigiri_stop_t *nigiri_get_stop(const nigiri_timetable_t *t, uint32_t idx);
+void nigiri_destroy_stop(const nigiri_stop_t *stop);
+
+void update_with_rt(nigiri_timetable_t *t);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/nigiri/abi.h
+++ b/include/nigiri/abi.h
@@ -1,5 +1,5 @@
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -9,56 +9,63 @@ struct nigiri_timetable;
 typedef struct nigiri_timetable nigiri_timetable_t;
 
 struct nigiri_transport {
-    //bitfield_idx_t bitfield_idx_;
-    uint32_t route_idx;
-    uint32_t n_event_mams;
-    int16_t *event_mams;
-    const char* name;
+  // bitfield_idx_t bitfield_idx_;
+  uint32_t route_idx;
+  uint32_t n_event_mams;
+  int16_t* event_mams;
+  const char* name;
 };
 typedef struct nigiri_transport nigiri_transport_t;
 
 struct nigiri_stop {
-    char *id;
-    char *name;
-    double lon;
-    double lat;
-    uint32_t transfer_time;
-    int32_t parent;
+  char* id;
+  char* name;
+  double lon;
+  double lat;
+  uint32_t transfer_time;
+  int32_t parent;
 };
 typedef struct nigiri_stop nigiri_stop_t;
 
 struct nigiri_route {
-    uint32_t n_stops;
-    uint32_t *stops;
-    uint32_t clasz;
+  uint32_t n_stops;
+  uint32_t* stops;
+  uint32_t clasz;
 };
 typedef struct nigiri_route nigiri_route_t;
 
 struct nigiri_event_change {
-    uint32_t transport_idx;
-    uint16_t day_idx;
-    uint32_t stop_idx;
-    bool is_departure;
-    int16_t delay;
-    bool cancelled;
+  uint32_t transport_idx;
+  uint16_t day_idx;
+  uint32_t stop_idx;
+  bool is_departure;
+  int16_t delay;
+  bool cancelled;
 };
 typedef struct nigiri_event_change nigiri_event_change_t;
 
-nigiri_timetable_t *nigiri_load(const char* path, int64_t from_ts, int64_t to_ts);
-void nigiri_destroy(const nigiri_timetable_t *t);
-int64_t nigiri_get_start_day_ts(const nigiri_timetable_t *t);
-uint16_t nigiri_get_day_count(const nigiri_timetable_t *t);
-uint32_t nigiri_get_transport_count(const nigiri_timetable_t *t);
-nigiri_transport_t *nigiri_get_transport(const nigiri_timetable_t *t, uint32_t idx);
-void nigiri_destroy_transport(const nigiri_transport_t *transport);
-bool nigiri_is_transport_active(const nigiri_timetable_t *t, const uint32_t transport_idx, uint16_t day_idx);
-nigiri_route_t *nigiri_get_route(const nigiri_timetable_t *t, uint32_t idx);
-void nigiri_destroy_route(const nigiri_route_t *route);
-uint32_t nigiri_get_stop_count(const nigiri_timetable_t *t);
-nigiri_stop_t *nigiri_get_stop(const nigiri_timetable_t *t, uint32_t idx);
-void nigiri_destroy_stop(const nigiri_stop_t *stop);
+nigiri_timetable_t* nigiri_load(const char* path,
+                                int64_t from_ts,
+                                int64_t to_ts);
+void nigiri_destroy(const nigiri_timetable_t* t);
+int64_t nigiri_get_start_day_ts(const nigiri_timetable_t* t);
+uint16_t nigiri_get_day_count(const nigiri_timetable_t* t);
+uint32_t nigiri_get_transport_count(const nigiri_timetable_t* t);
+nigiri_transport_t* nigiri_get_transport(const nigiri_timetable_t* t,
+                                         uint32_t idx);
+void nigiri_destroy_transport(const nigiri_transport_t* transport);
+bool nigiri_is_transport_active(const nigiri_timetable_t* t,
+                                const uint32_t transport_idx,
+                                uint16_t day_idx);
+nigiri_route_t* nigiri_get_route(const nigiri_timetable_t* t, uint32_t idx);
+void nigiri_destroy_route(const nigiri_route_t* route);
+uint32_t nigiri_get_stop_count(const nigiri_timetable_t* t);
+nigiri_stop_t* nigiri_get_stop(const nigiri_timetable_t* t, uint32_t idx);
+void nigiri_destroy_stop(const nigiri_stop_t* stop);
 
-void nigiri_update_with_rt(const nigiri_timetable_t *t, const char* gtfsrt_pb_path, void (*callback)(nigiri_event_change_t));
+void nigiri_update_with_rt(const nigiri_timetable_t* t,
+                           const char* gtfsrt_pb_path,
+                           void (*callback)(nigiri_event_change_t));
 
 #ifdef __cplusplus
 }

--- a/include/nigiri/abi.h
+++ b/include/nigiri/abi.h
@@ -9,17 +9,19 @@ struct nigiri_timetable;
 typedef struct nigiri_timetable nigiri_timetable_t;
 
 struct nigiri_transport {
-  // bitfield_idx_t bitfield_idx_;
   uint32_t route_idx;
   uint16_t n_event_mams;
   int16_t* event_mams;
   const char* name;
+  uint32_t name_len;
 };
 typedef struct nigiri_transport nigiri_transport_t;
 
 struct nigiri_location {
-  char* id;
-  char* name;
+  const char* id;
+  uint32_t id_len;
+  const char* name;
+  uint32_t name_len;
   double lon;
   double lat;
   uint16_t transfer_time;
@@ -28,9 +30,9 @@ struct nigiri_location {
 typedef struct nigiri_location nigiri_location_t;
 
 struct nigiri_route_stop {
-    uint32_t location_idx: 30;
-    bool in_allowed: 1;
-    bool out_allowed: 1;
+  uint32_t location_idx : 30;
+  bool in_allowed : 1;
+  bool out_allowed : 1;
 };
 typedef struct nigiri_route_stop nigiri_route_stop_t;
 
@@ -67,7 +69,8 @@ bool nigiri_is_transport_active(const nigiri_timetable_t* t,
 nigiri_route_t* nigiri_get_route(const nigiri_timetable_t* t, uint32_t idx);
 void nigiri_destroy_route(const nigiri_route_t* route);
 uint32_t nigiri_get_location_count(const nigiri_timetable_t* t);
-nigiri_location_t* nigiri_get_location(const nigiri_timetable_t* t, uint32_t idx);
+nigiri_location_t* nigiri_get_location(const nigiri_timetable_t* t,
+                                       uint32_t idx);
 void nigiri_destroy_location(const nigiri_location_t* location);
 
 void nigiri_update_with_rt(const nigiri_timetable_t* t,

--- a/include/nigiri/abi.h
+++ b/include/nigiri/abi.h
@@ -41,6 +41,7 @@ nigiri_transport_t *nigiri_get_transport(const nigiri_timetable_t *t, uint32_t i
 void nigiri_destroy_transport(const nigiri_transport_t *transport);
 nigiri_route_t *nigiri_get_route(const nigiri_timetable_t *t, uint32_t idx);
 void nigiri_destroy_route(const nigiri_route_t *route);
+uint32_t nigiri_get_stop_count(const nigiri_timetable_t *t);
 nigiri_stop_t *nigiri_get_stop(const nigiri_timetable_t *t, uint32_t idx);
 void nigiri_destroy_stop(const nigiri_stop_t *stop);
 

--- a/include/nigiri/abi.h
+++ b/include/nigiri/abi.h
@@ -36,7 +36,7 @@ typedef struct nigiri_route nigiri_route_t;
 
 struct nigiri_event_change {
     uint32_t transport_idx;
-    uint16_t day;
+    uint16_t day_idx;
     uint32_t stop_idx;
     bool is_departure;
     int16_t delay;
@@ -44,13 +44,14 @@ struct nigiri_event_change {
 };
 typedef struct nigiri_event_change nigiri_event_change_t;
 
-
 nigiri_timetable_t *nigiri_load(const char* path, int64_t from_ts, int64_t to_ts);
 void nigiri_destroy(const nigiri_timetable_t *t);
+int64_t nigiri_get_start_day_ts(const nigiri_timetable_t *t);
+uint16_t nigiri_get_day_count(const nigiri_timetable_t *t);
 uint32_t nigiri_get_transport_count(const nigiri_timetable_t *t);
 nigiri_transport_t *nigiri_get_transport(const nigiri_timetable_t *t, uint32_t idx);
-bool nigiri_is_transport_active(const nigiri_transport_t *transport, uint16_t day);
 void nigiri_destroy_transport(const nigiri_transport_t *transport);
+bool nigiri_is_transport_active(const nigiri_timetable_t *t, const uint32_t transport_idx, uint16_t day_idx);
 nigiri_route_t *nigiri_get_route(const nigiri_timetable_t *t, uint32_t idx);
 void nigiri_destroy_route(const nigiri_route_t *route);
 uint32_t nigiri_get_stop_count(const nigiri_timetable_t *t);

--- a/include/nigiri/rt/rt_timetable.h
+++ b/include/nigiri/rt/rt_timetable.h
@@ -10,7 +10,11 @@
 
 namespace nigiri {
 
-using change_callback_t = std::function<void(transport const t, stop_idx_t const stop_idx, event_type const ev_type, duration_t const delay, bool const cancelled)>;
+using change_callback_t = std::function<void(transport const t,
+                                             stop_idx_t const stop_idx,
+                                             event_type const ev_type,
+                                             duration_t const delay,
+                                             bool const cancelled)>;
 
 // General note:
 // - The real-time timetable does not use bitfields. It requires an initial copy
@@ -57,11 +61,13 @@ struct rt_timetable {
     change_callback_ = callback;
   }
 
-  void reset_change_callback() {
-    change_callback_ = nullptr;
-  }
+  void reset_change_callback() { change_callback_ = nullptr; }
 
-  void dispatch_event_change(transport const t, stop_idx_t const stop_idx, event_type const ev_type, duration_t const delay, bool const cancelled) {
+  void dispatch_event_change(transport const t,
+                             stop_idx_t const stop_idx,
+                             event_type const ev_type,
+                             duration_t const delay,
+                             bool const cancelled) {
     if (change_callback_) {
       change_callback_(t, stop_idx, ev_type, delay, cancelled);
     }
@@ -158,7 +164,6 @@ struct rt_timetable {
 
   // RT transport -> canceled flag
   bitvec rt_transport_is_cancelled_;
-
 
   change_callback_t change_callback_;
 };

--- a/include/nigiri/rt/rt_timetable.h
+++ b/include/nigiri/rt/rt_timetable.h
@@ -10,7 +10,7 @@
 
 namespace nigiri {
 
-using change_callback_t = std::function<void(transport const t,
+using change_callback_t = std::function<void(transport const transport,
                                              stop_idx_t const stop_idx,
                                              event_type const ev_type,
                                              duration_t const delay,

--- a/include/nigiri/types.h
+++ b/include/nigiri/types.h
@@ -106,7 +106,7 @@ using nvec = cista::raw::nvec<Key, T, N>;
 
 using bitfield_idx_t = cista::strong<std::uint32_t, struct _bitfield_idx>;
 using location_idx_t = cista::strong<std::uint32_t, struct _location_idx>;
-using route_idx_t = cista::strong<std::uint32_t, struct _location_idx>;
+using route_idx_t = cista::strong<std::uint32_t, struct _route_idx>;
 using section_idx_t = cista::strong<std::uint32_t, struct _section_idx>;
 using section_db_idx_t = cista::strong<std::uint32_t, struct _section_db_idx>;
 using trip_idx_t = cista::strong<std::uint32_t, struct _trip_idx>;

--- a/server/main.cc
+++ b/server/main.cc
@@ -3,6 +3,7 @@
 #include "date/date.h"
 
 #include "utl/helpers/algorithm.h"
+#include "utl/progress_tracker.h"
 #include "utl/verify.h"
 
 #include "nigiri/loader/gtfs/loader.h"
@@ -16,6 +17,9 @@ using namespace nigiri;
 using namespace nigiri::loader;
 
 int main(int ac, char** av) {
+  auto const progress_tracker = utl::activate_progress_tracker("server");
+  auto const silencer = utl::global_progress_bars{true};
+
   if (ac != 2) {
     fmt::print("usage: {} [TIMETABLE_PATH]\n",
                ac == 0U ? "nigiri-server" : av[0]);

--- a/src/abi.cc
+++ b/src/abi.cc
@@ -196,7 +196,9 @@ void nigiri_destroy_location(const nigiri_location_t* location) {
 
 void nigiri_update_with_rt_from_buf(const nigiri_timetable_t* t,
                                     std::string_view protobuf,
-                                    void (*callback)(nigiri_event_change)) {
+                                    void (*callback)(nigiri_event_change_t,
+                                                     void* context),
+                                    void* context) {
   auto const src = nigiri::source_idx_t{0U};
   auto const tag = "";
 
@@ -212,7 +214,7 @@ void nigiri_update_with_rt_from_buf(const nigiri_timetable_t* t,
             .is_departure = ev_type != nigiri::event_type::kArr,
             .delay = delay.count(),
             .cancelled = cancelled};
-        callback(c);
+        callback(c, context);
       };
 
   t->rtt->set_change_callback(rtt_callback);
@@ -230,7 +232,9 @@ void nigiri_update_with_rt_from_buf(const nigiri_timetable_t* t,
 
 void nigiri_update_with_rt(const nigiri_timetable_t* t,
                            const char* gtfsrt_pb_path,
-                           void (*callback)(nigiri_event_change)) {
+                           void (*callback)(nigiri_event_change_t,
+                                            void* context),
+                           void* context) {
   auto const file = cista::mmap{gtfsrt_pb_path, cista::mmap::protection::READ};
-  return nigiri_update_with_rt_from_buf(t, file.view(), callback);
+  return nigiri_update_with_rt_from_buf(t, file.view(), callback, context);
 }

--- a/src/abi.cc
+++ b/src/abi.cc
@@ -1,204 +1,225 @@
+#include <cstring>
+#include <filesystem>
 #include <memory>
 #include <vector>
-#include <filesystem>
-#include <cstring>
 
 #include "date/date.h"
 
 #include "utl/helpers/algorithm.h"
-#include "utl/verify.h"
 #include "utl/progress_tracker.h"
+#include "utl/verify.h"
 
 #include "nigiri/abi.h"
 
+#include "nigiri/loader/dir.h"
 #include "nigiri/loader/gtfs/loader.h"
 #include "nigiri/loader/hrd/loader.h"
-#include "nigiri/loader/dir.h"
 #include "nigiri/loader/init_finish.h"
 #include "nigiri/logging.h"
-#include "nigiri/timetable.h"
-#include "nigiri/rt/rt_timetable.h"
 #include "nigiri/rt/create_rt_timetable.h"
 #include "nigiri/rt/gtfsrt_update.h"
+#include "nigiri/rt/rt_timetable.h"
+#include "nigiri/timetable.h"
 
 #include "nigiri/common/interval.h"
 #include "cista/memory_holder.h"
 
 using namespace date;
 
-
 struct nigiri_timetable {
-    std::shared_ptr<nigiri::timetable> tt;
-    std::shared_ptr<nigiri::rt_timetable> rtt;
+  std::shared_ptr<nigiri::timetable> tt;
+  std::shared_ptr<nigiri::rt_timetable> rtt;
 };
 
-nigiri_timetable_t *nigiri_load(const char* path, int64_t start_ts, int64_t end_ts) {
-    auto const progress_tracker = utl::activate_progress_tracker("libnigiri");
-    auto const silencer = utl::global_progress_bars{true};
+nigiri_timetable_t* nigiri_load(const char* path,
+                                int64_t start_ts,
+                                int64_t end_ts) {
+  auto const progress_tracker = utl::activate_progress_tracker("libnigiri");
+  auto const silencer = utl::global_progress_bars{true};
 
-    auto loaders = std::vector<std::unique_ptr<nigiri::loader::loader_interface>>{};
-    loaders.emplace_back(std::make_unique<nigiri::loader::gtfs::gtfs_loader>());
-    loaders.emplace_back(std::make_unique<nigiri::loader::hrd::hrd_5_00_8_loader>());
-    loaders.emplace_back(std::make_unique<nigiri::loader::hrd::hrd_5_20_26_loader>());
-    loaders.emplace_back(std::make_unique<nigiri::loader::hrd::hrd_5_20_39_loader>());
-    loaders.emplace_back(std::make_unique<nigiri::loader::hrd::hrd_5_20_avv_loader>());
+  auto loaders =
+      std::vector<std::unique_ptr<nigiri::loader::loader_interface>>{};
+  loaders.emplace_back(std::make_unique<nigiri::loader::gtfs::gtfs_loader>());
+  loaders.emplace_back(
+      std::make_unique<nigiri::loader::hrd::hrd_5_00_8_loader>());
+  loaders.emplace_back(
+      std::make_unique<nigiri::loader::hrd::hrd_5_20_26_loader>());
+  loaders.emplace_back(
+      std::make_unique<nigiri::loader::hrd::hrd_5_20_39_loader>());
+  loaders.emplace_back(
+      std::make_unique<nigiri::loader::hrd::hrd_5_20_avv_loader>());
 
-    auto const src = nigiri::source_idx_t{0U};
-    auto const tt_path = std::filesystem::path{path};
-    auto const d = nigiri::loader::make_dir(tt_path);
+  auto const src = nigiri::source_idx_t{0U};
+  auto const tt_path = std::filesystem::path{path};
+  auto const d = nigiri::loader::make_dir(tt_path);
 
-    auto const c =
-        utl::find_if(loaders, [&](auto&& l) { return l->applicable(*d); });
-    utl::verify(c != end(loaders), "no loader applicable to {}", tt_path);
-    nigiri::log(nigiri::log_lvl::info, "main", "loading nigiri timetable with configuration {}", (*c)->name());
+  auto const c =
+      utl::find_if(loaders, [&](auto&& l) { return l->applicable(*d); });
+  utl::verify(c != end(loaders), "no loader applicable to {}", tt_path);
+  nigiri::log(nigiri::log_lvl::info, "main",
+              "loading nigiri timetable with configuration {}", (*c)->name());
 
-    nigiri_timetable_t *t = new nigiri_timetable_t;
-	t->tt = std::make_unique<nigiri::timetable>();
+  nigiri_timetable_t* t = new nigiri_timetable_t;
+  t->tt = std::make_unique<nigiri::timetable>();
 
-    std::string_view default_timezone_{ "Europe/Berlin" };
-    
-    t->tt->date_range_ = {floor<days>(std::chrono::system_clock::from_time_t((time_t)start_ts)),
-                    floor<days>(std::chrono::system_clock::from_time_t((time_t)end_ts))};
+  std::string_view default_timezone_{"Europe/Berlin"};
 
-    nigiri::loader::register_special_stations(*t->tt);
-    (*c)->load(
-        {
-            .link_stop_distance_ = 0,
-            .default_tz_ = default_timezone_
-        },
-        src, *d, *t->tt
-    );
-    nigiri::loader::finalize(*t->tt);
+  t->tt->date_range_ = {
+      floor<days>(std::chrono::system_clock::from_time_t((time_t)start_ts)),
+      floor<days>(std::chrono::system_clock::from_time_t((time_t)end_ts))};
 
-    t->rtt = std::make_shared<nigiri::rt_timetable>(nigiri::rt::create_rt_timetable(*t->tt, t->tt->date_range_.from_));
-	return t;
+  nigiri::loader::register_special_stations(*t->tt);
+  (*c)->load({.link_stop_distance_ = 0, .default_tz_ = default_timezone_}, src,
+             *d, *t->tt);
+  nigiri::loader::finalize(*t->tt);
+
+  t->rtt = std::make_shared<nigiri::rt_timetable>(
+      nigiri::rt::create_rt_timetable(*t->tt, t->tt->date_range_.from_));
+  return t;
 }
 
-void nigiri_destroy(const nigiri_timetable_t *t) {
-    t->~nigiri_timetable_t();
-    delete t;
+void nigiri_destroy(const nigiri_timetable_t* t) {
+  t->~nigiri_timetable_t();
+  delete t;
 }
 
-int64_t nigiri_get_start_day_ts(const nigiri_timetable_t *t) {
-    return std::chrono::system_clock::to_time_t(t->tt->internal_interval_days().from_);
+int64_t nigiri_get_start_day_ts(const nigiri_timetable_t* t) {
+  return std::chrono::system_clock::to_time_t(
+      t->tt->internal_interval_days().from_);
 }
 
-uint16_t nigiri_get_day_count(const nigiri_timetable_t *t) {
-    return t->tt->internal_interval_days().size().count();
+uint16_t nigiri_get_day_count(const nigiri_timetable_t* t) {
+  return t->tt->internal_interval_days().size().count();
 }
 
-char *create_new_cstring(std::string_view s) {
-    auto cstring = new char[s.length()+1];
-    s.copy(cstring, s.length());
-    cstring[s.length()] = '\0';
-    return cstring;
+char* create_new_cstring(std::string_view s) {
+  auto cstring = new char[s.length() + 1];
+  s.copy(cstring, s.length());
+  cstring[s.length()] = '\0';
+  return cstring;
 }
 
-uint32_t nigiri_get_transport_count(const nigiri_timetable_t *t) {
-    return t->tt->transport_route_.size();
+uint32_t nigiri_get_transport_count(const nigiri_timetable_t* t) {
+  return t->tt->transport_route_.size();
 }
 
-nigiri_transport_t *nigiri_get_transport(const nigiri_timetable_t *t, uint32_t idx) {
-    auto tidx = nigiri::transport_idx_t{idx};
-    auto transport = new nigiri_transport_t;
+nigiri_transport_t* nigiri_get_transport(const nigiri_timetable_t* t,
+                                         uint32_t idx) {
+  auto tidx = nigiri::transport_idx_t{idx};
+  auto transport = new nigiri_transport_t;
 
-    auto route_idx = t->tt->transport_route_[tidx];
+  auto route_idx = t->tt->transport_route_[tidx];
 
-    auto n_stops = t->tt->route_location_seq_[route_idx].size();
+  auto n_stops = t->tt->route_location_seq_[route_idx].size();
 
-    auto event_mams = new int16_t[(n_stops-1)*2]; 
-    size_t i;
-    for(i=0; i<n_stops; i++) {
-        if (i != 0) event_mams[i*2-1] = t->tt->event_mam(tidx, i, nigiri::event_type::kArr).count();
-        if (i != n_stops-1) event_mams[i*2] = t->tt->event_mam(tidx, i, nigiri::event_type::kDep).count();
-    }
-    transport->route_idx = static_cast<nigiri::route_idx_t::value_t>(route_idx);
-    transport->n_event_mams = (n_stops-1)*2;
-    transport->event_mams = event_mams;
-    transport->name = create_new_cstring(t->tt->transport_name(tidx));
-    return transport;
+  auto event_mams = new int16_t[(n_stops - 1) * 2];
+  size_t i;
+  for (i = 0; i < n_stops; i++) {
+    if (i != 0)
+      event_mams[i * 2 - 1] =
+          t->tt->event_mam(tidx, i, nigiri::event_type::kArr).count();
+    if (i != n_stops - 1)
+      event_mams[i * 2] =
+          t->tt->event_mam(tidx, i, nigiri::event_type::kDep).count();
+  }
+  transport->route_idx = static_cast<nigiri::route_idx_t::value_t>(route_idx);
+  transport->n_event_mams = (n_stops - 1) * 2;
+  transport->event_mams = event_mams;
+  transport->name = create_new_cstring(t->tt->transport_name(tidx));
+  return transport;
 }
 
-void nigiri_destroy_transport(const nigiri_transport_t *transport) {
-    delete[] transport->event_mams;
-    delete[] transport->name;
-    delete transport;
+void nigiri_destroy_transport(const nigiri_transport_t* transport) {
+  delete[] transport->event_mams;
+  delete[] transport->name;
+  delete transport;
 }
 
-bool nigiri_is_transport_active(const nigiri_timetable_t *t, const uint32_t transport_idx, uint16_t day_idx) {
-    auto tidx = nigiri::transport_idx_t{transport_idx};
-    return t->tt->bitfields_[t->tt->transport_traffic_days_[tidx]].test(day_idx);
+bool nigiri_is_transport_active(const nigiri_timetable_t* t,
+                                const uint32_t transport_idx,
+                                uint16_t day_idx) {
+  auto tidx = nigiri::transport_idx_t{transport_idx};
+  return t->tt->bitfields_[t->tt->transport_traffic_days_[tidx]].test(day_idx);
 }
 
-nigiri_route_t *nigiri_get_route(const nigiri_timetable_t *t, uint32_t idx) {
-    auto ridx = nigiri::route_idx_t{idx};
-    auto stops = t->tt->route_location_seq_[ridx];
-    auto n_stops = stops.size();
-    auto stops_idx = new uint32_t[n_stops];
-    size_t i;
-    for(i=0; i<n_stops; i++) {
-        stops_idx[i] = static_cast<nigiri::location_idx_t::value_t>(nigiri::stop{stops[i]}.location_idx()); 
-    }
-    auto route = new nigiri_route_t;
+nigiri_route_t* nigiri_get_route(const nigiri_timetable_t* t, uint32_t idx) {
+  auto ridx = nigiri::route_idx_t{idx};
+  auto stops = t->tt->route_location_seq_[ridx];
+  auto n_stops = stops.size();
+  auto stops_idx = new uint32_t[n_stops];
+  size_t i;
+  for (i = 0; i < n_stops; i++) {
+    stops_idx[i] = static_cast<nigiri::location_idx_t::value_t>(
+        nigiri::stop{stops[i]}.location_idx());
+  }
+  auto route = new nigiri_route_t;
 
-    route->stops = stops_idx;
-    route->n_stops = n_stops;
-    route->clasz = (uint32_t)t->tt->route_section_clasz_[ridx].front();
-    return route;
+  route->stops = stops_idx;
+  route->n_stops = n_stops;
+  route->clasz = (uint32_t)t->tt->route_section_clasz_[ridx].front();
+  return route;
 }
 
-void nigiri_destroy_route(const nigiri_route_t *route) {
-    delete[] route->stops;
-    delete route;
+void nigiri_destroy_route(const nigiri_route_t* route) {
+  delete[] route->stops;
+  delete route;
 }
 
-uint32_t nigiri_get_stop_count(const nigiri_timetable_t *t) {
-    return t->tt->n_locations();
+uint32_t nigiri_get_stop_count(const nigiri_timetable_t* t) {
+  return t->tt->n_locations();
 }
 
-nigiri_stop_t *nigiri_get_stop(const nigiri_timetable_t *t, uint32_t idx) {
-    auto lidx = nigiri::location_idx_t{idx};
-    auto stop = new nigiri_stop_t;
-    auto l = t->tt->locations_.get(lidx);
-    stop->name = create_new_cstring(l.name_);
-    stop->id = create_new_cstring(l.id_);
-    stop->lat = l.pos_.lat_;
-    stop->lon = l.pos_.lng_;
-    stop->transfer_time = l.transfer_time_.count();
-    stop->parent = static_cast<nigiri::location_idx_t::value_t>(l.parent_);
-    return stop;
+nigiri_stop_t* nigiri_get_stop(const nigiri_timetable_t* t, uint32_t idx) {
+  auto lidx = nigiri::location_idx_t{idx};
+  auto stop = new nigiri_stop_t;
+  auto l = t->tt->locations_.get(lidx);
+  stop->name = create_new_cstring(l.name_);
+  stop->id = create_new_cstring(l.id_);
+  stop->lat = l.pos_.lat_;
+  stop->lon = l.pos_.lng_;
+  stop->transfer_time = l.transfer_time_.count();
+  stop->parent = static_cast<nigiri::location_idx_t::value_t>(l.parent_);
+  return stop;
 }
 
-void nigiri_destroy_stop(const nigiri_stop_t *stop) {
-    delete[] stop->name;
-    delete[] stop->id;
-    delete stop;
+void nigiri_destroy_stop(const nigiri_stop_t* stop) {
+  delete[] stop->name;
+  delete[] stop->id;
+  delete stop;
 }
 
-void nigiri_update_with_rt(const nigiri_timetable_t *t, const char* gtfsrt_pb_path, void (*callback)(nigiri_event_change)) {
-    auto const src = nigiri::source_idx_t{0U};
-    auto const tag = "";
+void nigiri_update_with_rt(const nigiri_timetable_t* t,
+                           const char* gtfsrt_pb_path,
+                           void (*callback)(nigiri_event_change)) {
+  auto const src = nigiri::source_idx_t{0U};
+  auto const tag = "";
 
-    auto const rtt_callback = [&](nigiri::transport const t, nigiri::stop_idx_t const stop_idx, nigiri::event_type const ev_type, nigiri::duration_t const delay, bool const cancelled) {
+  auto const rtt_callback =
+      [&](nigiri::transport const t, nigiri::stop_idx_t const stop_idx,
+          nigiri::event_type const ev_type, nigiri::duration_t const delay,
+          bool const cancelled) {
         nigiri_event_change_t const c = {
-            .transport_idx = static_cast<nigiri::transport_idx_t::value_t>(t.t_idx_),
+            .transport_idx =
+                static_cast<nigiri::transport_idx_t::value_t>(t.t_idx_),
             .day_idx = static_cast<nigiri::day_idx_t::value_t>(t.day_),
             .stop_idx = stop_idx,
             .is_departure = ev_type != nigiri::event_type::kArr,
             .delay = delay.count(),
-            .cancelled = cancelled
-        };
+            .cancelled = cancelled};
         callback(c);
-    };
+      };
 
-    t->rtt->set_change_callback(rtt_callback);
-    try {
-        auto const file = cista::mmap{gtfsrt_pb_path, cista::mmap::protection::READ};
-        nigiri::rt::gtfsrt_update_buf(*t->tt, *t->rtt, src, tag, file.view());
-    } catch (std::exception const& e) {
-        nigiri::log(nigiri::log_lvl::error, "main", "GTFS-RT update error (tag={}) {}", tag, e.what());
-    } catch (...) {
-        nigiri::log(nigiri::log_lvl::error, "main", "Unknown GTFS-RT update error (tag={})", tag);
-    }
-    t->rtt->reset_change_callback();
+  t->rtt->set_change_callback(rtt_callback);
+  try {
+    auto const file =
+        cista::mmap{gtfsrt_pb_path, cista::mmap::protection::READ};
+    nigiri::rt::gtfsrt_update_buf(*t->tt, *t->rtt, src, tag, file.view());
+  } catch (std::exception const& e) {
+    nigiri::log(nigiri::log_lvl::error, "main",
+                "GTFS-RT update error (tag={}) {}", tag, e.what());
+  } catch (...) {
+    nigiri::log(nigiri::log_lvl::error, "main",
+                "Unknown GTFS-RT update error (tag={})", tag);
+  }
+  t->rtt->reset_change_callback();
 }

--- a/src/abi.cc
+++ b/src/abi.cc
@@ -114,21 +114,32 @@ void nigiri_destroy_transport(const nigiri_transport_t *transport) {
 
 nigiri_route_t *nigiri_get_route(const nigiri_timetable_t *t, uint32_t idx) {
     auto ridx = nigiri::route_idx_t{idx};
-    auto stops = t->tt->route_location_seq_[ridx]; 
+    auto stops = t->tt->route_location_seq_[ridx];
     auto n_stops = stops.size();
+    auto stops_idx = new uint32_t[n_stops];
+    size_t i;
+    for(i=0; i<n_stops; i++) {
+        stops_idx[i] = static_cast<nigiri::location_idx_t::value_t>(nigiri::stop{stops[i]}.location_idx()); 
+    }
     auto route = new nigiri_route_t;
-    route->stops = &stops.front();
+
+    route->stops = stops_idx;
     route->n_stops = n_stops;
     route->clasz = (uint32_t)t->tt->route_section_clasz_[ridx].front();
     return route;
 }
 
 void nigiri_destroy_route(const nigiri_route_t *route) {
+    delete[] route->stops;
     delete route;
 }
 
+uint32_t nigiri_get_stop_count(const nigiri_timetable_t *t) {
+    return t->tt->n_locations();
+}
+
 nigiri_stop_t *nigiri_get_stop(const nigiri_timetable_t *t, uint32_t idx) {
-    auto lidx = nigiri::stop{idx}.location_idx();
+    auto lidx = nigiri::location_idx_t{idx};
     auto stop = new nigiri_stop_t;
     auto l = t->tt->locations_.get(lidx);
     stop->name = create_new_cstring(l.name_);

--- a/src/abi.cc
+++ b/src/abi.cc
@@ -1,0 +1,147 @@
+#include <vector>
+#include <filesystem>
+#include <cstring>
+
+#include "date/date.h"
+
+#include "utl/helpers/algorithm.h"
+#include "utl/verify.h"
+#include "utl/progress_tracker.h"
+
+#include "nigiri/abi.h"
+
+#include "nigiri/loader/gtfs/loader.h"
+#include "nigiri/loader/hrd/loader.h"
+#include "nigiri/loader/dir.h"
+#include "nigiri/loader/init_finish.h"
+#include "nigiri/logging.h"
+#include "nigiri/timetable.h"
+#include "nigiri/rt/rt_timetable.h"
+#include "nigiri/common/interval.h"
+#include "cista/memory_holder.h"
+
+using namespace date;
+
+
+struct nigiri_timetable {
+    std::shared_ptr<nigiri::timetable> tt;
+    nigiri::rt_timetable rtt;
+};
+
+nigiri_timetable_t *nigiri_load(const char* path, int64_t start_ts, int64_t end_ts) {
+    auto const progress_tracker = utl::activate_progress_tracker("libnigiri");
+    auto const silencer = utl::global_progress_bars{true};
+
+    auto loaders = std::vector<std::unique_ptr<nigiri::loader::loader_interface>>{};
+    loaders.emplace_back(std::make_unique<nigiri::loader::gtfs::gtfs_loader>());
+    loaders.emplace_back(std::make_unique<nigiri::loader::hrd::hrd_5_00_8_loader>());
+    loaders.emplace_back(std::make_unique<nigiri::loader::hrd::hrd_5_20_26_loader>());
+    loaders.emplace_back(std::make_unique<nigiri::loader::hrd::hrd_5_20_39_loader>());
+    loaders.emplace_back(std::make_unique<nigiri::loader::hrd::hrd_5_20_avv_loader>());
+
+    auto const src = nigiri::source_idx_t{0U};
+    auto const tt_path = std::filesystem::path{path};
+    auto const d = nigiri::loader::make_dir(tt_path);
+
+    auto const c =
+        utl::find_if(loaders, [&](auto&& l) { return l->applicable(*d); });
+    utl::verify(c != end(loaders), "no loader applicable to {}", tt_path);
+    nigiri::log(nigiri::log_lvl::info, "main", "loading nigiri timetable with configuration {}", (*c)->name());
+
+    nigiri_timetable_t *t = new nigiri_timetable_t;
+	t->tt = std::make_unique<nigiri::timetable>();
+
+    std::string_view default_timezone_{ "Europe/Berlin" };
+    
+    t->tt->date_range_ = {floor<days>(std::chrono::system_clock::from_time_t((time_t)start_ts)),
+                    floor<days>(std::chrono::system_clock::from_time_t((time_t)end_ts))};
+
+    nigiri::loader::register_special_stations(*t->tt);
+    (*c)->load(
+        {
+            .link_stop_distance_ = 0,
+            .default_tz_ = default_timezone_
+        },
+        src, *d, *t->tt
+    );
+    nigiri::loader::finalize(*t->tt);
+
+	return t;
+}
+
+void nigiri_destroy(const nigiri_timetable_t *t) {
+    t->~nigiri_timetable_t();
+    delete t;
+}
+
+char *create_new_cstring(std::string_view s) {
+    auto cstring = new char[s.length()+1];
+    s.copy(cstring, s.length());
+    cstring[s.length()] = '\0';
+    return cstring;
+}
+
+uint32_t nigiri_get_transport_count(const nigiri_timetable_t *t) {
+    return t->tt->transport_route_.size();
+}
+
+nigiri_transport_t *nigiri_get_transport(const nigiri_timetable_t *t, uint32_t idx) {
+    auto tidx = nigiri::transport_idx_t{idx};
+    auto transport = new nigiri_transport_t;
+
+    auto route_idx = t->tt->transport_route_[tidx];
+
+    auto n_stops = t->tt->route_location_seq_[route_idx].size();
+
+    auto event_mams = new int16_t[(n_stops-1)*2]; 
+    size_t i;
+    for(i=0; i<n_stops; i++) {
+        if (i != 0) event_mams[i*2-1] = t->tt->event_mam(tidx, i, nigiri::event_type::kArr).count();
+        if (i != n_stops-1) event_mams[i*2] = t->tt->event_mam(tidx, i, nigiri::event_type::kDep).count();
+    }
+    transport->route_idx = static_cast<nigiri::route_idx_t::value_t>(route_idx);
+    transport->n_event_mams = (n_stops-1)*2;
+    transport->event_mams = event_mams;
+    transport->name = create_new_cstring(t->tt->transport_name(tidx));
+    return transport;
+}
+
+void nigiri_destroy_transport(const nigiri_transport_t *transport) {
+    delete[] transport->event_mams;
+    delete[] transport->name;
+    delete transport;
+}
+
+nigiri_route_t *nigiri_get_route(const nigiri_timetable_t *t, uint32_t idx) {
+    auto ridx = nigiri::route_idx_t{idx};
+    auto stops = t->tt->route_location_seq_[ridx]; 
+    auto n_stops = stops.size();
+    auto route = new nigiri_route_t;
+    route->stops = &stops.front();
+    route->n_stops = n_stops;
+    route->clasz = (uint32_t)t->tt->route_section_clasz_[ridx].front();
+    return route;
+}
+
+void nigiri_destroy_route(const nigiri_route_t *route) {
+    delete route;
+}
+
+nigiri_stop_t *nigiri_get_stop(const nigiri_timetable_t *t, uint32_t idx) {
+    auto lidx = nigiri::stop{idx}.location_idx();
+    auto stop = new nigiri_stop_t;
+    auto l = t->tt->locations_.get(lidx);
+    stop->name = create_new_cstring(l.name_);
+    stop->id = create_new_cstring(l.id_);
+    stop->lat = l.pos_.lat_;
+    stop->lon = l.pos_.lng_;
+    stop->transfer_time = l.transfer_time_.count();
+    stop->parent = static_cast<nigiri::location_idx_t::value_t>(l.parent_);
+    return stop;
+}
+
+void nigiri_destroy_stop(const nigiri_stop_t *stop) {
+    delete[] stop->name;
+    delete[] stop->id;
+    delete stop;
+}

--- a/src/abi.cc
+++ b/src/abi.cc
@@ -94,13 +94,6 @@ uint16_t nigiri_get_day_count(const nigiri_timetable_t* t) {
   return static_cast<uint16_t>(t->tt->internal_interval_days().size().count());
 }
 
-char* create_new_cstring(std::string_view s) {
-  auto cstring = new char[s.length() + 1];
-  s.copy(cstring, s.length());
-  cstring[s.length()] = '\0';
-  return cstring;
-}
-
 uint32_t nigiri_get_transport_count(const nigiri_timetable_t* t) {
   return t->tt->transport_route_.size();
 }
@@ -134,13 +127,13 @@ nigiri_transport_t* nigiri_get_transport(const nigiri_timetable_t* t,
   transport->route_idx = static_cast<nigiri::route_idx_t::value_t>(route_idx);
   transport->n_event_mams = (static_cast<uint16_t>(n_stops) - 1) * 2;
   transport->event_mams = event_mams;
-  transport->name = create_new_cstring(t->tt->transport_name(tidx));
+  transport->name = t->tt->transport_name(tidx).data();
+  transport->name_len = t->tt->transport_name(tidx).length();
   return transport;
 }
 
 void nigiri_destroy_transport(const nigiri_transport_t* transport) {
   delete[] transport->event_mams;
-  delete[] transport->name;
   delete transport;
 }
 
@@ -164,20 +157,21 @@ nigiri_route_t* nigiri_get_route(const nigiri_timetable_t* t, uint32_t idx) {
   return route;
 }
 
-void nigiri_destroy_route(const nigiri_route_t* route) {
-  delete route;
-}
+void nigiri_destroy_route(const nigiri_route_t* route) { delete route; }
 
 uint32_t nigiri_get_location_count(const nigiri_timetable_t* t) {
   return t->tt->n_locations();
 }
 
-nigiri_location_t* nigiri_get_location(const nigiri_timetable_t* t, uint32_t idx) {
+nigiri_location_t* nigiri_get_location(const nigiri_timetable_t* t,
+                                       uint32_t idx) {
   auto lidx = nigiri::location_idx_t{idx};
   auto location = new nigiri_location_t;
   auto l = t->tt->locations_.get(lidx);
-  location->name = create_new_cstring(l.name_);
-  location->id = create_new_cstring(l.id_);
+  location->name = l.name_.data();
+  location->name_len = l.name_.length();
+  location->id = l.id_.data();
+  location->id_len = l.id_.length();
   location->lat = l.pos_.lat_;
   location->lon = l.pos_.lng_;
   location->transfer_time = static_cast<uint16_t>(l.transfer_time_.count());
@@ -186,8 +180,6 @@ nigiri_location_t* nigiri_get_location(const nigiri_timetable_t* t, uint32_t idx
 }
 
 void nigiri_destroy_location(const nigiri_location_t* location) {
-  delete[] location->name;
-  delete[] location->id;
   delete location;
 }
 

--- a/src/abi.cc
+++ b/src/abi.cc
@@ -155,14 +155,9 @@ nigiri_route_t* nigiri_get_route(const nigiri_timetable_t* t, uint32_t idx) {
   auto ridx = nigiri::route_idx_t{idx};
   auto stops = t->tt->route_location_seq_[ridx];
   auto n_stops = stops.size();
-  auto stops_idx = new uint32_t[n_stops];
-  for (size_t i = 0; i < n_stops; i++) {
-    stops_idx[i] = static_cast<nigiri::location_idx_t::value_t>(
-        nigiri::stop{stops[i]}.location_idx());
-  }
   auto route = new nigiri_route_t;
 
-  route->stops = stops_idx;
+  route->stops = reinterpret_cast<nigiri_route_stop_t*>(&stops.front());
   route->n_stops = static_cast<uint16_t>(n_stops);
   route->clasz =
       static_cast<uint16_t>(t->tt->route_section_clasz_[ridx].front());
@@ -170,31 +165,30 @@ nigiri_route_t* nigiri_get_route(const nigiri_timetable_t* t, uint32_t idx) {
 }
 
 void nigiri_destroy_route(const nigiri_route_t* route) {
-  delete[] route->stops;
   delete route;
 }
 
-uint32_t nigiri_get_stop_count(const nigiri_timetable_t* t) {
+uint32_t nigiri_get_location_count(const nigiri_timetable_t* t) {
   return t->tt->n_locations();
 }
 
-nigiri_stop_t* nigiri_get_stop(const nigiri_timetable_t* t, uint32_t idx) {
+nigiri_location_t* nigiri_get_location(const nigiri_timetable_t* t, uint32_t idx) {
   auto lidx = nigiri::location_idx_t{idx};
-  auto stop = new nigiri_stop_t;
+  auto location = new nigiri_location_t;
   auto l = t->tt->locations_.get(lidx);
-  stop->name = create_new_cstring(l.name_);
-  stop->id = create_new_cstring(l.id_);
-  stop->lat = l.pos_.lat_;
-  stop->lon = l.pos_.lng_;
-  stop->transfer_time = static_cast<uint16_t>(l.transfer_time_.count());
-  stop->parent = static_cast<nigiri::location_idx_t::value_t>(l.parent_);
-  return stop;
+  location->name = create_new_cstring(l.name_);
+  location->id = create_new_cstring(l.id_);
+  location->lat = l.pos_.lat_;
+  location->lon = l.pos_.lng_;
+  location->transfer_time = static_cast<uint16_t>(l.transfer_time_.count());
+  location->parent = static_cast<nigiri::location_idx_t::value_t>(l.parent_);
+  return location;
 }
 
-void nigiri_destroy_stop(const nigiri_stop_t* stop) {
-  delete[] stop->name;
-  delete[] stop->id;
-  delete stop;
+void nigiri_destroy_location(const nigiri_location_t* location) {
+  delete[] location->name;
+  delete[] location->id;
+  delete location;
 }
 
 void nigiri_update_with_rt(const nigiri_timetable_t* t,

--- a/src/abi.cc
+++ b/src/abi.cc
@@ -100,7 +100,7 @@ uint32_t nigiri_get_transport_count(const nigiri_timetable_t* t) {
 
 nigiri_transport_t* nigiri_get_transport(const nigiri_timetable_t* t,
                                          uint32_t idx) {
-  auto tidx = nigiri::transport_idx_t{idx};
+  auto const tidx = nigiri::transport_idx_t{idx};
   auto transport = new nigiri_transport_t;
 
   auto route_idx = t->tt->transport_route_[tidx];
@@ -141,18 +141,17 @@ void nigiri_destroy_transport(const nigiri_transport_t* transport) {
 bool nigiri_is_transport_active(const nigiri_timetable_t* t,
                                 const uint32_t transport_idx,
                                 uint16_t day_idx) {
-  auto tidx = nigiri::transport_idx_t{transport_idx};
+  auto const tidx = nigiri::transport_idx_t{transport_idx};
   return t->tt->bitfields_[t->tt->transport_traffic_days_[tidx]].test(day_idx);
 }
 
 nigiri_route_t* nigiri_get_route(const nigiri_timetable_t* t, uint32_t idx) {
-  auto ridx = nigiri::route_idx_t{idx};
+  auto const ridx = nigiri::route_idx_t{idx};
   auto stops = t->tt->route_location_seq_[ridx];
-  auto n_stops = stops.size();
+  auto const n_stops = stops.size();
   auto route_stops = new nigiri_route_stop_t[n_stops];
-  for (size_t i = 0; i < n_stops; i++) {
-    route_stops[i] = std::bit_cast<nigiri_route_stop_t>(stops[i]);
-  }
+  std::memcpy(route_stops, &stops.front(),
+              sizeof(nigiri_route_stop_t) * n_stops);
 
   auto route = new nigiri_route_t;
 
@@ -174,7 +173,7 @@ uint32_t nigiri_get_location_count(const nigiri_timetable_t* t) {
 
 nigiri_location_t* nigiri_get_location(const nigiri_timetable_t* t,
                                        uint32_t idx) {
-  auto lidx = nigiri::location_idx_t{idx};
+  auto const lidx = nigiri::location_idx_t{idx};
   auto location = new nigiri_location_t;
   auto l = t->tt->locations_.get(lidx);
   location->name = l.name_.data();

--- a/src/clasz.cc
+++ b/src/clasz.cc
@@ -198,7 +198,7 @@ clasz get_clasz(std::string_view s) {
     case hash("Drahtseilbahn"):
     case hash("Standseilbahn"):
     case hash("Sesselbahn"):
-    case hash("Gondola): return claszle car"):
+    case hash("Gondola"):
     case hash("Aufzug"):
     case hash("Elevator"): [[fallthrough]];
     case hash("ASC"): return clasz::kOther;

--- a/src/rt/gtfsrt_update.cc
+++ b/src/rt/gtfsrt_update.cc
@@ -97,7 +97,8 @@ delay_propagation update_event(timetable const& tt,
     rtt.update_time(
         r.rt_, stop_idx, ev_type,
         pred_time.has_value() ? std::max(*pred_time, new_time) : new_time);
-    rtt.dispatch_event_change(r.t_, stop_idx, ev_type, new_time - static_time, false);
+    rtt.dispatch_event_change(r.t_, stop_idx, ev_type, new_time - static_time,
+                              false);
     return {new_time, new_time - static_time};
   }
 }

--- a/src/rt/gtfsrt_update.cc
+++ b/src/rt/gtfsrt_update.cc
@@ -73,6 +73,7 @@ delay_propagation update_delay(timetable const& tt,
   rtt.update_time(r.rt_, stop_idx, ev_type,
                   min.has_value() ? std::max(*min, static_time + delay)
                                   : static_time + delay);
+  rtt.dispatch_event_change(r.t_, stop_idx, ev_type, delay, false);
   return {rtt.unix_event_time(r.rt_, stop_idx, ev_type), delay};
 }
 
@@ -96,6 +97,7 @@ delay_propagation update_event(timetable const& tt,
     rtt.update_time(
         r.rt_, stop_idx, ev_type,
         pred_time.has_value() ? std::max(*pred_time, new_time) : new_time);
+    rtt.dispatch_event_change(r.t_, stop_idx, ev_type, new_time - static_time, false);
     return {new_time, new_time - static_time};
   }
 }

--- a/test/abi_test.cc
+++ b/test/abi_test.cc
@@ -328,9 +328,7 @@ auto const kTripUpdate =
  ]
 })"s;
 
-}  // namespace
-
-static int test_event_change_counter = 0;
+auto test_event_change_counter = 0;  // NOLINT
 
 void my_test_callback(nigiri_event_change_t evt) {
   EXPECT_EQ(0, evt.transport_idx);
@@ -375,29 +373,31 @@ void my_test_callback(nigiri_event_change_t evt) {
   test_event_change_counter++;
 }
 
+}  // namespace
+
 TEST(rt, abi_1) {
 
-  auto t = nigiri_load_from_dir(
+  auto const t = nigiri_load_from_dir(
       test_files(),
       std::chrono::system_clock::to_time_t(date::sys_days{2023_y / August / 9}),
       std::chrono::system_clock::to_time_t(
           date::sys_days{2023_y / August / 12}));
 
-  auto transport_count = nigiri_get_transport_count(t);
+  auto const transport_count = nigiri_get_transport_count(t);
   EXPECT_EQ(1, transport_count);
 
-  auto location_count = nigiri_get_location_count(t);
+  auto const location_count = nigiri_get_location_count(t);
   EXPECT_EQ(37, location_count);
 
-  auto l0 = nigiri_get_location(t, 0);
-  std::string l0_name(l0->name, l0->name_len);
+  auto const l0 = nigiri_get_location(t, 0);
+  auto const l0_name = std::string{l0->name, l0->name_len};
   EXPECT_EQ("START", l0_name);
   nigiri_destroy_location(l0);
 
-  auto l9 = nigiri_get_location(t, 9);
-  std::string l9_name(l9->name, l9->name_len);
+  auto const l9 = nigiri_get_location(t, 9);
+  auto const l9_name = std::string{l9->name, l9->name_len};
   EXPECT_EQ("Block Line Station", l9_name);
-  std::string l9_id(l9->id, l9->id_len);
+  auto const l9_id = std::string{l9->id, l9->id_len};
   EXPECT_EQ("2351", l9_id);
   EXPECT_FLOAT_EQ(43.422095, l9->lat);
   EXPECT_FLOAT_EQ(-80.462740, l9->lon);
@@ -405,10 +405,10 @@ TEST(rt, abi_1) {
   EXPECT_EQ(0, l9->parent);
   nigiri_destroy_location(l9);
 
-  auto l35 = nigiri_get_location(t, 35);
-  std::string l35_name(l35->name, l35->name_len);
+  auto const l35 = nigiri_get_location(t, 35);
+  auto const l35_name = std::string{l35->name, l35->name_len};
   EXPECT_EQ("King / Manulife", l35_name);
-  std::string l35_id(l35->id, l35->id_len);
+  auto const l35_id = std::string{l35->id, l35->id_len};
   EXPECT_EQ("1918", l35_id);
   EXPECT_FLOAT_EQ(43.491207, l35->lat);
   EXPECT_FLOAT_EQ(-80.528026, l35->lon);
@@ -416,10 +416,10 @@ TEST(rt, abi_1) {
   EXPECT_EQ(33, l35->parent);
   nigiri_destroy_location(l35);
 
-  auto l36 = nigiri_get_location(t, location_count - 1);
-  std::string l36_name(l36->name, l36->name_len);
+  auto const l36 = nigiri_get_location(t, location_count - 1);
+  auto const l36_name = std::string{l36->name, l36->name_len};
   EXPECT_EQ("Conestoga Station", l36_name);
-  std::string l36_id(l36->id, l36->id_len);
+  auto const l36_id = std::string{l36->id, l36->id_len};
   EXPECT_EQ("1127", l36_id);
   EXPECT_FLOAT_EQ(43.498036, l36->lat);
   EXPECT_FLOAT_EQ(-80.528999, l36->lon);
@@ -432,7 +432,7 @@ TEST(rt, abi_1) {
       nigiri_get_start_day_ts(t));
   EXPECT_EQ(9, nigiri_get_day_count(t));
 
-  auto transport = nigiri_get_transport(t, 0);
+  auto const transport = nigiri_get_transport(t, 0);
   EXPECT_EQ(0, transport->route_idx);
   EXPECT_EQ(54, transport->n_event_mams);
   EXPECT_EQ(555, transport->event_mams[0]);
@@ -440,10 +440,10 @@ TEST(rt, abi_1) {
   EXPECT_EQ(556, transport->event_mams[2]);
   EXPECT_EQ(596, transport->event_mams[transport->n_event_mams - 2]);
   EXPECT_EQ(598, transport->event_mams[transport->n_event_mams - 1]);
-  std::string t_name(transport->name, transport->name_len);
+  auto const t_name = std::string{transport->name, transport->name_len};
   EXPECT_EQ("Tram iXpress Fischer-Hallman", t_name);
 
-  auto route = nigiri_get_route(t, transport->route_idx);
+  auto const route = nigiri_get_route(t, transport->route_idx);
   EXPECT_EQ(28, route->n_stops);
   EXPECT_EQ(9, route->clasz);
   EXPECT_EQ(9, route->stops[0].location_idx);

--- a/test/abi_test.cc
+++ b/test/abi_test.cc
@@ -1,0 +1,474 @@
+#include "gtest/gtest.h"
+
+#include "date/date.h"
+
+#include "nigiri/loader/dir.h"
+#include "nigiri/abi.h"
+#include "nigiri/rt/util.h"
+
+nigiri_timetable_t* nigiri_load_from_dir(nigiri::loader::dir const& d,
+                                         int64_t from_ts,
+                                         int64_t to_ts);
+void nigiri_update_with_rt_from_buf(const nigiri_timetable_t* t,
+                                    std::string_view protobuf,
+                                    void (*callback)(nigiri_event_change));
+
+using namespace nigiri;
+using namespace nigiri::loader;
+using namespace nigiri::rt;
+using namespace date;
+using namespace std::chrono_literals;
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+
+namespace {
+
+mem_dir test_files() {
+  return mem_dir::read(R"(
+     "(
+# agency.txt
+agency_name,agency_url,agency_timezone,agency_lang,agency_phone,agency_fare_url,agency_id
+"grt",https://grt.ca,America/New_York,en,519-585-7555,http://www.grt.ca/en/fares/FarePrices.asp,grt
+
+# stops.txt
+stop_id,stop_code,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,wheelchair_boarding,platform_code
+2351,2351,Block Line Station,,  43.422095, -80.462740,,
+1033,1033,Block Line / Hanover,,  43.419023, -80.466600,,,0,,1,
+2086,2086,Block Line / Kingswood,,  43.417796, -80.473666,,,0,,1,
+2885,2885,Block Line / Strasburg,,  43.415733, -80.480340,,,0,,1,
+2888,2888,Block Line / Laurentian,,  43.412766, -80.491494,,,0,,1,
+3189,3189,Block Line / Westmount,,  43.411515, -80.498966,,,0,,1,
+3895,3895,Fischer-Hallman / Westmount,,  43.406717, -80.500091,,,0,,1,
+3893,3893,Fischer-Hallman / Activa,,  43.414221, -80.508534,,,0,,1,
+2969,2969,Fischer-Hallman / Ottawa,,  43.416570, -80.510880,,,0,,1,
+2971,2971,Fischer-Hallman / Mcgarry,,  43.423420, -80.518818,,,0,,1,
+2986,2986,Fischer-Hallman / Queens,,  43.428585, -80.523337,,,0,,1,
+3891,3891,Fischer-Hallman / Highland,,  43.431587, -80.525376,,,0,,1,
+3143,3143,Fischer-Hallman / Victoria,,  43.436843, -80.529202,,,0,,1,
+3144,3144,Fischer-Hallman / Stoke,,  43.439462, -80.535435,,,0,,1,
+3146,3146,Fischer-Hallman / University Ave.,,  43.444402, -80.545691,,,0,,1,
+1992,1992,Fischer-Hallman / Thorndale,,  43.448678, -80.550034,,,0,,1,
+1972,1972,Fischer-Hallman / Erb,,  43.452906, -80.553686,,,0,,1,
+3465,3465,Fischer-Hallman / Keats Way,,  43.458370, -80.557824,,,0,,1,
+3890,3890,Fischer-Hallman / Columbia,,  43.467368, -80.565646,,,0,,1,
+1117,1117,Columbia / U.W. - Columbia Lake Village,,  43.469091, -80.561788,,,0,,1,
+3899,3899,Columbia / University Of Waterloo,,  43.474462, -80.546591,,,0,,1,
+1223,1223,University Of Waterloo Station,,  43.474023, -80.540433,,
+3887,3887,Phillip / Columbia,,  43.476409, -80.539399,,,0,,1,
+2524,2524,Columbia / Hazel,,  43.480027, -80.531130,,,0,,1,
+4073,4073,King / Columbia,,  43.482448, -80.526106,,,0,,1,
+1916,1916,King / Weber,,  43.484988, -80.526677,,,0,,1,
+1918,1918,King / Manulife,,  43.491207, -80.528026,,,0,4073,1,
+1127,1127,Conestoga Station,,  43.498036, -80.528999,,
+
+# calendar_dates.txt
+service_id,date,exception_type
+201-Weekday-66-23SUMM-1111100,20230703,1
+201-Weekday-66-23SUMM-1111100,20230704,1
+201-Weekday-66-23SUMM-1111100,20230705,1
+201-Weekday-66-23SUMM-1111100,20230706,1
+201-Weekday-66-23SUMM-1111100,20230707,1
+201-Weekday-66-23SUMM-1111100,20230710,1
+201-Weekday-66-23SUMM-1111100,20230711,1
+201-Weekday-66-23SUMM-1111100,20230712,1
+201-Weekday-66-23SUMM-1111100,20230713,1
+201-Weekday-66-23SUMM-1111100,20230714,1
+201-Weekday-66-23SUMM-1111100,20230717,1
+201-Weekday-66-23SUMM-1111100,20230718,1
+201-Weekday-66-23SUMM-1111100,20230719,1
+201-Weekday-66-23SUMM-1111100,20230720,1
+201-Weekday-66-23SUMM-1111100,20230721,1
+201-Weekday-66-23SUMM-1111100,20230724,1
+201-Weekday-66-23SUMM-1111100,20230725,1
+201-Weekday-66-23SUMM-1111100,20230726,1
+201-Weekday-66-23SUMM-1111100,20230727,1
+201-Weekday-66-23SUMM-1111100,20230728,1
+201-Weekday-66-23SUMM-1111100,20230731,1
+201-Weekday-66-23SUMM-1111100,20230801,1
+201-Weekday-66-23SUMM-1111100,20230802,1
+201-Weekday-66-23SUMM-1111100,20230803,1
+201-Weekday-66-23SUMM-1111100,20230804,1
+201-Weekday-66-23SUMM-1111100,20230808,1
+201-Weekday-66-23SUMM-1111100,20230809,1
+201-Weekday-66-23SUMM-1111100,20230810,1
+201-Weekday-66-23SUMM-1111100,20230811,1
+201-Weekday-66-23SUMM-1111100,20230814,1
+201-Weekday-66-23SUMM-1111100,20230815,1
+201-Weekday-66-23SUMM-1111100,20230816,1
+201-Weekday-66-23SUMM-1111100,20230817,1
+201-Weekday-66-23SUMM-1111100,20230818,1
+201-Weekday-66-23SUMM-1111100,20230821,1
+201-Weekday-66-23SUMM-1111100,20230822,1
+201-Weekday-66-23SUMM-1111100,20230823,1
+201-Weekday-66-23SUMM-1111100,20230824,1
+201-Weekday-66-23SUMM-1111100,20230825,1
+201-Weekday-66-23SUMM-1111100,20230828,1
+201-Weekday-66-23SUMM-1111100,20230829,1
+201-Weekday-66-23SUMM-1111100,20230830,1
+201-Weekday-66-23SUMM-1111100,20230831,1
+201-Weekday-66-23SUMM-1111100,20230901,1
+
+# routes.txt
+route_id,agency_id,route_short_name,route_long_name,route_desc,route_type
+201,grt,iXpress Fischer-Hallman,,3,https://www.grt.ca/en/schedules-maps/schedules.aspx
+
+# trips.txt
+route_id,service_id,trip_id,trip_headsign,direction_id,block_id,shape_id,wheelchair_accessible,bikes_allowed
+201,201-Weekday-66-23SUMM-1111100,3248651,Conestoga Station,0,340341,2010025,1,1
+
+# stop_times.txt
+trip_id,arrival_time,departure_time,stop_id,stop_sequence,pickup_type,drop_off_type
+3248651,05:15:00,05:15:00,2351,1,0,0
+3248651,05:16:00,05:16:00,1033,2,0,0
+3248651,05:18:00,05:18:00,2086,3,0,0
+3248651,05:19:00,05:19:00,2885,4,0,0
+3248651,05:21:00,05:21:00,2888,5,0,0
+3248651,05:22:00,05:22:00,3189,6,0,0
+3248651,05:24:00,05:24:00,3895,7,0,0
+3248651,05:26:00,05:26:00,3893,8,0,0
+3248651,05:27:00,05:27:00,2969,9,0,0
+3248651,05:29:00,05:29:00,2971,10,0,0
+3248651,05:31:00,05:31:00,2986,11,0,0
+3248651,05:32:00,05:32:00,3891,12,0,0
+3248651,05:33:00,05:33:00,3143,13,0,0
+3248651,05:35:00,05:35:00,3144,14,0,0
+3248651,05:37:00,05:37:00,3146,15,0,0
+3248651,05:38:00,05:38:00,1992,16,0,0
+3248651,05:39:00,05:39:00,1972,17,0,0
+3248651,05:40:00,05:40:00,3465,18,0,0
+3248651,05:42:00,05:42:00,3890,19,0,0
+3248651,05:43:00,05:43:00,1117,20,0,0
+3248651,05:46:00,05:46:00,3899,21,0,0
+3248651,05:47:00,05:49:00,1223,22,0,0
+3248651,05:50:00,05:50:00,3887,23,0,0
+3248651,05:53:00,05:53:00,2524,24,0,0
+3248651,05:54:00,05:54:00,4073,25,0,0
+3248651,05:55:00,05:55:00,1916,26,0,0
+3248651,05:56:00,05:56:00,1918,27,0,0
+3248651,05:58:00,05:58:00,1127,28,1,0
+)");
+}
+
+auto const kTripUpdate =
+    R"({
+ "header": {
+  "gtfsRealtimeVersion": "2.0",
+  "incrementality": "FULL_DATASET",
+  "timestamp": "1691660324"
+ },
+ "entity": [
+  {
+    "id": "3248651",
+    "isDeleted": false,
+    "tripUpdate": {
+     "trip": {
+      "tripId": "3248651",
+      "startTime": "05:15:00",
+      "startDate": "20230810",
+      "routeId": "201"
+     },
+     "stopTimeUpdate": [
+      {
+       "stopSequence": 15,
+       "arrival": {
+        "time": "1691660288"
+       },
+       "departure": {
+        "time": "1691660288"
+       },
+       "stopId": "3146",
+       "scheduleRelationship": "SCHEDULED"
+      },
+      {
+       "stopSequence": 16,
+       "arrival": {
+        "time": "1691660351"
+       },
+       "departure": {
+        "time": "1691660351"
+       },
+       "stopId": "1992",
+       "scheduleRelationship": "SCHEDULED"
+      },
+      {
+       "stopSequence": 17,
+       "arrival": {
+        "time": "1691660431"
+       },
+       "departure": {
+        "time": "1691660431"
+       },
+       "stopId": "1972",
+       "scheduleRelationship": "SCHEDULED"
+      },
+      {
+       "stopSequence": 18,
+       "arrival": {
+        "time": "1691660496"
+       },
+       "departure": {
+        "time": "1691660496"
+       },
+       "stopId": "3465",
+       "scheduleRelationship": "SCHEDULED"
+      },
+      {
+       "stopSequence": 19,
+       "arrival": {
+        "time": "1691660669"
+       },
+       "departure": {
+        "time": "1691660669"
+       },
+       "stopId": "3890",
+       "scheduleRelationship": "SCHEDULED"
+      },
+      {
+       "stopSequence": 20,
+       "arrival": {
+        "time": "1691660718"
+       },
+       "departure": {
+        "time": "1691660718"
+       },
+       "stopId": "1117",
+       "scheduleRelationship": "SCHEDULED"
+      },
+      {
+       "stopSequence": 21,
+       "arrival": {
+        "time": "1691660869"
+       },
+       "departure": {
+        "time": "1691660869"
+       },
+       "stopId": "3899",
+       "scheduleRelationship": "SCHEDULED"
+      },
+      {
+       "stopSequence": 22,
+       "arrival": {
+        "time": "1691660943"
+       },
+       "departure": {
+        "time": "1691660943"
+       },
+       "stopId": "1223",
+       "scheduleRelationship": "SCHEDULED"
+      },
+      {
+       "stopSequence": 23,
+       "arrival": {
+        "time": "1691661004"
+       },
+       "departure": {
+        "time": "1691661004"
+       },
+       "stopId": "3887",
+       "scheduleRelationship": "SCHEDULED"
+      },
+      {
+       "stopSequence": 24,
+       "arrival": {
+        "time": "1691661152"
+       },
+       "departure": {
+        "time": "1691661152"
+       },
+       "stopId": "2524",
+       "scheduleRelationship": "SCHEDULED"
+      },
+      {
+       "stopSequence": 25,
+       "arrival": {
+        "time": "1691661240"
+       },
+       "departure": {
+        "time": "1691661240"
+       },
+       "stopId": "4073",
+       "scheduleRelationship": "SCHEDULED"
+      },
+      {
+       "stopSequence": 26,
+       "arrival": {
+        "time": "1691661276"
+       },
+       "departure": {
+        "time": "1691661276"
+       },
+       "stopId": "1916",
+       "scheduleRelationship": "SCHEDULED"
+      },
+      {
+       "stopSequence": 27,
+       "arrival": {
+        "time": "1691661366"
+       },
+       "departure": {
+        "time": "1691661366"
+       },
+       "stopId": "1918",
+       "scheduleRelationship": "SCHEDULED"
+      },
+      {
+       "stopSequence": 28,
+       "arrival": {
+        "time": "1691661480"
+       },
+       "departure": {
+        "time": "1691661480"
+       },
+       "stopId": "1127",
+       "scheduleRelationship": "SCHEDULED"
+      }
+     ]
+    }
+  }
+ ]
+})"s;
+
+}  // namespace
+
+static int test_event_change_counter = 0;
+
+void my_test_callback(nigiri_event_change_t evt) {
+  EXPECT_EQ(0, evt.transport_idx);
+  EXPECT_EQ(6, evt.day_idx);
+  EXPECT_EQ(false, evt.cancelled);
+
+  if (test_event_change_counter == 0) {
+    EXPECT_EQ(14, evt.stop_idx);
+    EXPECT_EQ(false, evt.is_departure);
+    EXPECT_EQ(1, evt.delay);
+  }
+  if (test_event_change_counter == 1) {
+    EXPECT_EQ(14, evt.stop_idx);
+    EXPECT_EQ(true, evt.is_departure);
+    EXPECT_EQ(1, evt.delay);
+  }
+  if (test_event_change_counter == 8) {
+    EXPECT_EQ(18, evt.stop_idx);
+    EXPECT_EQ(false, evt.is_departure);
+    EXPECT_EQ(2, evt.delay);
+  }
+  if (test_event_change_counter == 9) {
+    EXPECT_EQ(18, evt.stop_idx);
+    EXPECT_EQ(true, evt.is_departure);
+    EXPECT_EQ(2, evt.delay);
+  }
+  if (test_event_change_counter == 22) {
+    EXPECT_EQ(25, evt.stop_idx);
+    EXPECT_EQ(false, evt.is_departure);
+    EXPECT_EQ(-1, evt.delay);
+  }
+  if (test_event_change_counter == 23) {
+    EXPECT_EQ(25, evt.stop_idx);
+    EXPECT_EQ(true, evt.is_departure);
+    EXPECT_EQ(-1, evt.delay);
+  }
+  if (test_event_change_counter == 26) {
+    EXPECT_EQ(27, evt.stop_idx);
+    EXPECT_EQ(false, evt.is_departure);
+    EXPECT_EQ(0, evt.delay);
+  }
+  test_event_change_counter++;
+}
+
+TEST(rt, abi_1) {
+
+  auto t = nigiri_load_from_dir(
+      test_files(),
+      std::chrono::system_clock::to_time_t(date::sys_days{2023_y / August / 9}),
+      std::chrono::system_clock::to_time_t(
+          date::sys_days{2023_y / August / 12}));
+
+  auto transport_count = nigiri_get_transport_count(t);
+  EXPECT_EQ(1, transport_count);
+
+  auto location_count = nigiri_get_location_count(t);
+  EXPECT_EQ(37, location_count);
+
+  auto l0 = nigiri_get_location(t, 0);
+  std::string l0_name(l0->name, l0->name_len);
+  EXPECT_EQ("START", l0_name);
+  nigiri_destroy_location(l0);
+
+  auto l9 = nigiri_get_location(t, 9);
+  std::string l9_name(l9->name, l9->name_len);
+  EXPECT_EQ("Block Line Station", l9_name);
+  std::string l9_id(l9->id, l9->id_len);
+  EXPECT_EQ("2351", l9_id);
+  EXPECT_FLOAT_EQ(43.422095, l9->lat);
+  EXPECT_FLOAT_EQ(-80.462740, l9->lon);
+  EXPECT_EQ(2, l9->transfer_time);
+  EXPECT_EQ(0, l9->parent);
+  nigiri_destroy_location(l9);
+
+  auto l35 = nigiri_get_location(t, 35);
+  std::string l35_name(l35->name, l35->name_len);
+  EXPECT_EQ("King / Manulife", l35_name);
+  std::string l35_id(l35->id, l35->id_len);
+  EXPECT_EQ("1918", l35_id);
+  EXPECT_FLOAT_EQ(43.491207, l35->lat);
+  EXPECT_FLOAT_EQ(-80.528026, l35->lon);
+  EXPECT_EQ(2, l35->transfer_time);
+  EXPECT_EQ(33, l35->parent);
+  nigiri_destroy_location(l35);
+
+  auto l36 = nigiri_get_location(t, location_count - 1);
+  std::string l36_name(l36->name, l36->name_len);
+  EXPECT_EQ("Conestoga Station", l36_name);
+  std::string l36_id(l36->id, l36->id_len);
+  EXPECT_EQ("1127", l36_id);
+  EXPECT_FLOAT_EQ(43.498036, l36->lat);
+  EXPECT_FLOAT_EQ(-80.528999, l36->lon);
+  EXPECT_EQ(2, l36->transfer_time);
+  EXPECT_EQ(0, l36->parent);
+  nigiri_destroy_location(l36);
+
+  EXPECT_EQ(
+      std::chrono::system_clock::to_time_t(date::sys_days{2023_y / August / 4}),
+      nigiri_get_start_day_ts(t));
+  EXPECT_EQ(9, nigiri_get_day_count(t));
+
+  auto transport = nigiri_get_transport(t, 0);
+  EXPECT_EQ(0, transport->route_idx);
+  EXPECT_EQ(54, transport->n_event_mams);
+  EXPECT_EQ(555, transport->event_mams[0]);
+  EXPECT_EQ(556, transport->event_mams[1]);
+  EXPECT_EQ(556, transport->event_mams[2]);
+  EXPECT_EQ(596, transport->event_mams[transport->n_event_mams - 2]);
+  EXPECT_EQ(598, transport->event_mams[transport->n_event_mams - 1]);
+  std::string t_name(transport->name, transport->name_len);
+  EXPECT_EQ("Tram iXpress Fischer-Hallman", t_name);
+
+  auto route = nigiri_get_route(t, transport->route_idx);
+  EXPECT_EQ(28, route->n_stops);
+  EXPECT_EQ(9, route->clasz);
+  EXPECT_EQ(9, route->stops[0].location_idx);
+  EXPECT_EQ(true, route->stops[0].in_allowed);
+  EXPECT_EQ(true, route->stops[0].out_allowed);
+  EXPECT_EQ(36, route->stops[route->n_stops - 1].location_idx);
+  EXPECT_EQ(false, route->stops[route->n_stops - 1].in_allowed);
+  EXPECT_EQ(true, route->stops[route->n_stops - 1].out_allowed);
+
+  EXPECT_EQ(false, nigiri_is_transport_active(t, 0, 0));
+  EXPECT_EQ(false, nigiri_is_transport_active(t, 0, 1));
+  EXPECT_EQ(false, nigiri_is_transport_active(t, 0, 2));
+  EXPECT_EQ(false, nigiri_is_transport_active(t, 0, 3));
+  EXPECT_EQ(false, nigiri_is_transport_active(t, 0, 4));
+  EXPECT_EQ(true, nigiri_is_transport_active(t, 0, 5));
+  EXPECT_EQ(true, nigiri_is_transport_active(t, 0, 6));
+  EXPECT_EQ(true, nigiri_is_transport_active(t, 0, 7));
+  EXPECT_EQ(false, nigiri_is_transport_active(t, 0, 8));
+
+  nigiri_destroy_route(route);
+  nigiri_destroy_transport(transport);
+
+  auto const msg = rt::json_to_protobuf(kTripUpdate);
+  nigiri_update_with_rt_from_buf(t, msg, &my_test_callback);
+  EXPECT_EQ(27, test_event_change_counter);
+
+  nigiri_destroy(t);
+}


### PR DESCRIPTION
As discussed previously, this PR enables a limited subset of nigiri to be used by other non C++ code. This is just a draft as a basis for further discussion. I have no experience in C++ whatsoever, so please review carefully.

As an example, the wrapping Rust crate(s) I have created are available at [traines-source/motis-nigiri-rust](https://github.com/traines-source/motis-nigiri-rust).

A couple of decisions/questions that need discussion:
1. I have decided to create a pure C wrapper that then can be wrapped by the C-ABI compatible language of your choice. While it is possible to have other programming languages interface with C++ directly, this is usually not recommended (see e.g. [here](https://stackoverflow.com/a/75556744/1666456) and [here](https://docs.rust-embedded.org/book/interoperability/rust-with-c.html#building-a-c-api)). The C++ ABI might not be as stable and in particular you pull all sorts of things from the C++ stdlib into your interface. To a certain extent, these types can be treated as opaque, but it's a huge hassle. Rust-specific alternatives like [cxx](https://github.com/dtolnay/cxx) can do this, but I think this would make it more difficult (or impossible?) to use the ABI from other languages.
2. Instead of providing getters for everything, the functions return (pointers to) structs.
3. The caller is responsible to call the respective `*_destroy_*` functions after being done. The nigiri lib then properly frees the memory (see a similar approach [here](https://github.com/google-deepmind/open_spiel/commit/669c3234376c79b6125fee6ddaa7ca7aa0efe409)). I chose this approach originally because some struct fields might actually be pointers to nigiri-internal data to avoid copying. But I think by now, most things are copied anyways, for a variety of reasons (e.g. strings need to be copied to be null-terminated, alternative: separate length field).
4. This unfortunately means that most things are copied at least twice (in the C wrapper and most likely in the calling code).
5. The nigiri lib has loads of dependencies. It is quite a hassle to link all of them in the right order without the help of CMake. In my Rust wrapper, I grep through the verbose output of `ninja` to find them, [this is](https://github.com/traines-source/motis-nigiri-rust/blob/master/nigiri-sys/build.sh#L6) [quite hacky](https://github.com/traines-source/motis-nigiri-rust/blob/master/nigiri-sys/build.rs#L12). I wonder whether there is a better solution (but [I'm not the first one](https://stackoverflow.com/questions/74851275/rust-cargo-cmake-integration-with-c-library-dependencies)). Maybe one could try to build an alternative version of the nigiri lib that statically links all dependencies, but this doesn't seem to be very straightforward either.
6. I decided to expose transports that are not yet exploded by days. This enables callers to leverage the bitfield advantages. However, the bitfield is not transferred in the `nigiri_transport` struct (this would be quite cumbersome in pure C), instead, the function `nigiri_is_transport_active` is provided.
7. How do we handle transports added in RT? Do we extend the `nigiri_event_change` struct to cover all necessary information? Or do we just add an `rt_added` flag to that struct and a function `nigiri_get_rt_transport` that allows to retrieve from the `rt_timetable` but otherwise has the same signature as `nigiri_get_transport`?
8. Why does a route have multiple claszes (`timetable.route_section_clasz_`)? Is this to allow for trains that are e.g. both RE and IC? Currently just taking the first.
9. Commit `f13753b` contains some unrelated fixes of things that I stumbled upon. 

TODOs:
- [x] in/out_allowed
- [ ] RT: handle track changes, cancellations/skipped, transports only in RT, possibly more RT special cases
- [ ] expose footpaths
- [ ] extend structs with further relevant fields (?)
- [ ] verify correctness of timestamp handling (currently, caller is responsible for resolution of base_day + day_idx + event_mam)
- [ ] error handling
- [x] tests (there are some tests in [motis-nigiri-rust](https://github.com/traines-source/motis-nigiri-rust))
- [ ] passive initialization. Currently, the caller has to initiate loading of the timetable. For other usecases, it might be useful to register some form of callback to be able to use a timetable that someone else (the main motis process) is loading. 