### PR TITLE
Clang 17 compatibility

### DIFF
--- a/include/nigiri/loader/hrd/service/service.h
+++ b/include/nigiri/loader/hrd/service/service.h
@@ -41,8 +41,6 @@ struct specification {
 
 struct service {
   static const constexpr auto kTimeNotSet = -1;  // NOLINT
-  static category unknown_catergory;
-  static provider unknown_provider;
 
   struct event {
     int time_;

--- a/include/nigiri/types.h
+++ b/include/nigiri/types.h
@@ -207,19 +207,19 @@ using duration_t = i16_minutes;
 using unixtime_t = std::chrono::sys_time<i32_minutes>;
 using local_time = date::local_time<i32_minutes>;
 
-constexpr u8_minutes operator"" _i8_minutes(unsigned long long n) {
+constexpr u8_minutes operator""_i8_minutes(unsigned long long n) {
   return duration_t{n};
 }
 
-constexpr duration_t operator"" _minutes(unsigned long long n) {
+constexpr duration_t operator""_minutes(unsigned long long n) {
   return duration_t{n};
 }
 
-constexpr duration_t operator"" _hours(unsigned long long n) {
+constexpr duration_t operator""_hours(unsigned long long n) {
   return duration_t{n * 60U};
 }
 
-constexpr duration_t operator"" _days(unsigned long long n) {
+constexpr duration_t operator""_days(unsigned long long n) {
   return duration_t{n * 1440U};
 }
 


### PR DESCRIPTION
See individual commits for details, mainly fixing new warnings that break the build due to -Werror being set here.

That however only fixes half of the overall problem, `date` still needs a solution. That is unlikely to get upstream fixes for C++20 compatibility it seems (as it itself has become part of C++20 in slightly modified form), but with that new API appearing in libc++ we end up with a few clashes and/or ambiguities.