### PR TITLE
Classify unknown HVT route types based on the corresponding value range

### DIFF
--- a/src/loader/gtfs/route.cc
+++ b/src/loader/gtfs/route.cc
@@ -114,9 +114,21 @@ clasz to_clasz(int const route_type) {
     case 1506 /* Private Hire Service Vehicle */:
     case 1507 /* All Taxi Services */:
     case 1700 /* Miscellaneous Service */:
-    case 1702 /* Horse-drawn Carriage */:
-    default: return clasz::kOther;
+    case 1702 /* Horse-drawn Carriage */: return clasz::kOther;
   }
+
+  // types not in the above table but within category type ranges
+  if (route_type >= 1000 && route_type < 1100) {
+    return clasz::kShip;
+  }
+  if (route_type >= 1100 && route_type < 1200) {
+    return clasz::kAir;
+  }
+  if (route_type >= 1200 && route_type < 1300) {
+    return clasz::kShip;
+  }
+
+  return clasz::kOther;
 }
 
 color_t to_color(std::string_view const color_str) {

--- a/test/loader/gtfs/route_test.cc
+++ b/test/loader/gtfs/route_test.cc
@@ -39,7 +39,7 @@ TEST(gtfs, read_routes_berlin_data) {
       read_routes(tt, timezones, agencies,
                   berlin_files().get_file(kRoutesFile).data(), "CET");
 
-  EXPECT_EQ(8, routes.size());
+  EXPECT_EQ(9, routes.size());
 
   ASSERT_NE(end(routes), routes.find("1"));
   EXPECT_EQ("ANG---", tt.providers_[routes.at("1")->agency_].short_name_);
@@ -62,4 +62,7 @@ TEST(gtfs, read_routes_berlin_data) {
   EXPECT_EQ(clasz::kRegional, routes.at("812")->clasz_);
   EXPECT_EQ(color_t{0xFFB10093}, routes.at("812")->color_);
   EXPECT_EQ(color_t{0xFFFFFFFF}, routes.at("812")->text_color_);
+
+  ASSERT_NE(end(routes), routes.find("F11"));
+  EXPECT_EQ(clasz::kShip, routes.at("F11")->clasz_);
 }

--- a/test/loader/gtfs/test_data.cc
+++ b/test/loader/gtfs/test_data.cc
@@ -136,6 +136,7 @@ constexpr auto const berlin_routes_file_content =
 810,N04---,,"S+U Lichtenberg Bhf (Berlin) -- Senftenberg, Bahnhof",,100,http://www.vbb.de,,
 811,N04---,,"S+U Lichtenberg Bhf (Berlin) -- Altdöbern, Bahnhof",,100,http://www.vbb.de,,
 812,N04---,RB14,,,100,http://www.vbb.de,B10093,FFFFFF
+F11,F04---,,,,1203,,,
 )";
 
 constexpr auto const berlin_trips_file_content =


### PR DESCRIPTION
Such types are for example in use in the Norwegian Entur feed for air and water transport, and were previously classified as "other".