### PR TITLE
Increase timezone index to 16bit

### DIFF
--- a/include/nigiri/types.h
+++ b/include/nigiri/types.h
@@ -116,7 +116,7 @@ using trip_id_idx_t = cista::strong<std::uint32_t, struct _trip_id_str_idx>;
 using transport_idx_t = cista::strong<std::uint32_t, struct _transport_idx>;
 using source_idx_t = cista::strong<std::uint8_t, struct _source_idx>;
 using day_idx_t = cista::strong<std::uint16_t, struct _day_idx>;
-using timezone_idx_t = cista::strong<std::uint8_t, struct _timezone_idx>;
+using timezone_idx_t = cista::strong<std::uint16_t, struct _timezone_idx>;
 using merged_trips_idx_t =
     cista::strong<std::uint32_t, struct _merged_trips_idx>;
 using footpath_idx_t = cista::strong<std::uint32_t, struct _footpath_idx>;


### PR DESCRIPTION
This fixes a heap overflow when loading the current Transitous dataset.

Fixes https://github.com/public-transport/transitous/issues/81.