### PR TITLE
Max search interval

### DIFF
--- a/include/nigiri/routing/interval_estimate.h
+++ b/include/nigiri/routing/interval_estimate.h
@@ -15,9 +15,10 @@ struct interval_estimator {
       : tt_{tt}, q_{q} {
 
     auto const start_itv = std::visit(
-        utl::overloaded{
-            [](unixtime_t const& ut) { return interval<unixtime_t>{ut, ut}; },
-            [](interval<unixtime_t> iut) { return iut; }},
+        utl::overloaded{[](unixtime_t const& ut) {
+                          return interval<unixtime_t>{ut, ut};
+                        },
+                        [](interval<unixtime_t> iut) { return iut; }},
         q.start_time_);
 
     data_type_max_interval_ = {start_itv.from_ - kMaxSearchIntervalSize,

--- a/include/nigiri/routing/interval_estimate.h
+++ b/include/nigiri/routing/interval_estimate.h
@@ -20,8 +20,8 @@ struct interval_estimator {
             [](interval<unixtime_t> iut) { return iut; }},
         q.start_time_);
 
-    data_type_max_interval_ = {start_itv.from_ - kMaxTravelTime,
-                               start_itv.from_ + kMaxTravelTime};
+    data_type_max_interval_ = {start_itv.from_ - kMaxSearchIntervalSize,
+                               start_itv.from_ + kMaxSearchIntervalSize};
   }
 
   interval<unixtime_t> initial(interval<unixtime_t> const& itv) const {

--- a/include/nigiri/routing/interval_estimate.h
+++ b/include/nigiri/routing/interval_estimate.h
@@ -15,24 +15,13 @@ struct interval_estimator {
       : tt_{tt}, q_{q} {
 
     auto const start_itv = std::visit(
-        utl::overloaded{[](unixtime_t const& ut) {
-                          return interval<unixtime_t>{ut, ut};
-                        },
-                        [](interval<unixtime_t> iut) { return iut; }},
+        utl::overloaded{
+            [](unixtime_t const& ut) { return interval<unixtime_t>{ut, ut}; },
+            [](interval<unixtime_t> iut) { return iut; }},
         q.start_time_);
 
-    auto const ext = kMaxSearchIntervalSize - start_itv.size();
-
-    if (q.extend_interval_earlier_ && q.extend_interval_later_) {
-      data_type_max_interval_ = {start_itv.from_ - ext / 2,
-                                 start_itv.to_ + ext / 2};
-    } else if (q.extend_interval_earlier_) {
-      data_type_max_interval_ = {start_itv.from_ - ext, start_itv.to_};
-    } else if (q.extend_interval_later_) {
-      data_type_max_interval_ = {start_itv.from_, start_itv.to_ + ext};
-    } else {
-      data_type_max_interval_ = start_itv;
-    }
+    data_type_max_interval_ = {start_itv.from_ - kMaxTravelTime,
+                               start_itv.from_ + kMaxTravelTime};
   }
 
   interval<unixtime_t> initial(interval<unixtime_t> const& itv) const {

--- a/include/nigiri/routing/limits.h
+++ b/include/nigiri/routing/limits.h
@@ -9,6 +9,7 @@ namespace nigiri::routing {
 static constexpr auto const kMaxTransfers = std::uint8_t{7U};
 static constexpr auto const kMaxTravelTime = 1_days;
 constexpr auto const kMaxSearchIntervalSize =
-    date::days{std::numeric_limits<duration_t::rep>::max() / 1440};
+    date::days{std::numeric_limits<duration_t::rep>::max() / 1440} -
+    kMaxTravelTime;
 
 }  // namespace nigiri::routing


### PR DESCRIPTION
fixes reconstruction failures due to search interval becoming to large for duration_t data type