### PR TITLE
Global bitfield indices

### DIFF
--- a/include/nigiri/loader/gtfs/load_timetable.h
+++ b/include/nigiri/loader/gtfs/load_timetable.h
@@ -12,6 +12,11 @@ namespace nigiri::loader::gtfs {
 
 cista::hash_t hash(dir const& d);
 bool applicable(dir const&);
-void load_timetable(loader_config const&, source_idx_t, dir const&, timetable&);
+void load_timetable(loader_config const&,
+                    source_idx_t,
+                    dir const&,
+                    timetable&,
+                    std::shared_ptr<hash_map<bitfield, bitfield_idx_t>>
+                        global_bitfield_indices = nullptr);
 
 }  // namespace nigiri::loader::gtfs

--- a/include/nigiri/loader/gtfs/loader.h
+++ b/include/nigiri/loader/gtfs/loader.h
@@ -9,7 +9,9 @@ struct gtfs_loader : public loader_interface {
   void load(loader_config const&,
             source_idx_t const,
             dir const&,
-            timetable&) const override;
+            timetable&,
+            std::shared_ptr<hash_map<bitfield, bitfield_idx_t>> const&)
+      const override;
   cista::hash_t hash(dir const&) const override;
   std::string_view name() const override;
 };

--- a/include/nigiri/loader/hrd/load_timetable.h
+++ b/include/nigiri/loader/hrd/load_timetable.h
@@ -14,6 +14,11 @@ bool applicable(config const&, dir const&);
 
 std::uint64_t hash(config const&, dir const&, std::uint64_t seed = {});
 
-void load_timetable(source_idx_t, config const&, dir const&, timetable&);
+void load_timetable(source_idx_t,
+                    config const&,
+                    dir const&,
+                    timetable&,
+                    std::shared_ptr<hash_map<bitfield, bitfield_idx_t>> const&
+                        global_bitfield_indices = nullptr);
 
 }  // namespace nigiri::loader::hrd

--- a/include/nigiri/loader/hrd/loader.h
+++ b/include/nigiri/loader/hrd/loader.h
@@ -11,7 +11,9 @@ struct hrd_loader : public loader_interface {
   void load(loader_config const&,
             source_idx_t const src,
             dir const& d,
-            timetable& tt) const override;
+            timetable& tt,
+            std::shared_ptr<hash_map<bitfield, bitfield_idx_t>> const&)
+      const override;
   cista::hash_t hash(dir const&) const override;
   nigiri::loader::hrd::config config_;
 };

--- a/include/nigiri/loader/hrd/service/service_builder.h
+++ b/include/nigiri/loader/hrd/service/service_builder.h
@@ -14,7 +14,10 @@
 namespace nigiri::loader::hrd {
 
 struct service_builder {
-  explicit service_builder(stamm&, timetable&);
+  explicit service_builder(
+      stamm&,
+      timetable&,
+      std::shared_ptr<hash_map<bitfield, bitfield_idx_t>> const&);
 
   void add_services(config const& c,
                     char const* filename,
@@ -36,7 +39,7 @@ private:
   service_store store_;
   hash_map<std::basic_string<attribute_idx_t>, attribute_combination_idx_t>
       attribute_combinations_;
-  hash_map<bitfield, bitfield_idx_t> bitfield_indices_;
+  std::shared_ptr<hash_map<bitfield, bitfield_idx_t>> bitfield_indices_;
   interval<std::chrono::sys_days> selection_;
 
   mutable_fws_multimap<location_idx_t, route_idx_t> location_routes_;

--- a/include/nigiri/loader/loader_interface.h
+++ b/include/nigiri/loader/loader_interface.h
@@ -27,7 +27,9 @@ struct loader_interface {
   virtual void load(loader_config const&,
                     source_idx_t,
                     dir const&,
-                    timetable&) const = 0;
+                    timetable&,
+                    std::shared_ptr<hash_map<bitfield, bitfield_idx_t>> const&
+                        global_bitfield_indices = nullptr) const = 0;
   virtual cista::hash_t hash(dir const&) const = 0;
   virtual std::string_view name() const = 0;
 };

--- a/src/loader/gtfs/loader.cc
+++ b/src/loader/gtfs/loader.cc
@@ -8,11 +8,15 @@ bool gtfs_loader::applicable(dir const& d) const {
   return nigiri::loader::gtfs::applicable(d);
 }
 
-void gtfs_loader::load(loader_config const& c,
-                       source_idx_t const src,
-                       dir const& d,
-                       timetable& tt) const {
-  return nigiri::loader::gtfs::load_timetable(c, src, d, tt);
+void gtfs_loader::load(
+    loader_config const& c,
+    source_idx_t const src,
+    dir const& d,
+    timetable& tt,
+    std::shared_ptr<hash_map<bitfield, bitfield_idx_t>> const&
+        global_bitfield_indices) const {
+  return nigiri::loader::gtfs::load_timetable(c, src, d, tt,
+                                              global_bitfield_indices);
 }
 
 cista::hash_t gtfs_loader::hash(dir const& d) const {

--- a/src/loader/hrd/load_timetable.cc
+++ b/src/loader/hrd/load_timetable.cc
@@ -60,7 +60,9 @@ std::uint64_t hash(config const& c, dir const& d, std::uint64_t const seed) {
 void load_timetable(source_idx_t const src,
                     config const& c,
                     dir const& d,
-                    timetable& tt) {
+                    timetable& tt,
+                    std::shared_ptr<hash_map<bitfield, bitfield_idx_t>> const&
+                        global_bitfield_indices) {
   auto st = stamm{c, tt, d};
 
   auto progress_tracker = utl::get_active_progress_tracker();
@@ -75,7 +77,7 @@ void load_timetable(source_idx_t const src,
                | utl::sum());
   auto total_bytes_processed = std::uint64_t{0U};
 
-  auto sb = service_builder{st, tt};
+  auto sb = service_builder{st, tt, global_bitfield_indices};
   for (auto const& path : d.list_files(c.prefix(d) / c.fplan_)) {
     if (path.filename().generic_string().starts_with(".") ||
         (!c.fplan_file_extension_.empty() &&

--- a/src/loader/hrd/loader.cc
+++ b/src/loader/hrd/loader.cc
@@ -13,8 +13,11 @@ bool hrd_loader::applicable(dir const& d) const {
 void hrd_loader::load(loader_config const&,
                       source_idx_t const src,
                       dir const& d,
-                      timetable& tt) const {
-  return nigiri::loader::hrd::load_timetable(src, config_, d, tt);
+                      timetable& tt,
+                      std::shared_ptr<hash_map<bitfield, bitfield_idx_t>> const&
+                          global_bitfield_indices) const {
+  return nigiri::loader::hrd::load_timetable(src, config_, d, tt,
+                                             global_bitfield_indices);
 }
 
 cista::hash_t hrd_loader::hash(dir const& d) const {

--- a/src/loader/hrd/service/service_builder.cc
+++ b/src/loader/hrd/service/service_builder.cc
@@ -46,8 +46,18 @@ void service_builder::add_service(ref_service&& s) {
   }
 }
 
-service_builder::service_builder(stamm& s, timetable& tt)
-    : stamm_{s}, tt_{tt} {}
+service_builder::service_builder(
+    stamm& s,
+    timetable& tt,
+    std::shared_ptr<hash_map<bitfield, bitfield_idx_t>> const&
+        global_bitfield_indices)
+    : stamm_{s}, tt_{tt} {
+  bitfield_indices_ =
+      global_bitfield_indices != nullptr
+          ? global_bitfield_indices
+          : std::make_shared<hash_map<bitfield, bitfield_idx_t>>(
+                hash_map<bitfield, bitfield_idx_t>{});
+}
 
 void service_builder::add_services(config const& c,
                                    const char* filename,
@@ -200,7 +210,7 @@ void service_builder::write_services(source_idx_t const src) {
           auto const merged_trip = tt_.register_merged_trip({id});
           tt_.add_transport(timetable::transport{
               .bitfield_idx_ = utl::get_or_create(
-                  bitfield_indices_, s.utc_traffic_days_,
+                  *bitfield_indices_, s.utc_traffic_days_,
                   [&]() { return tt_.register_bitfield(s.utc_traffic_days_); }),
               .route_idx_ = route_idx,
               .first_dep_offset_ = 0_minutes,

--- a/src/loader/load.cc
+++ b/src/loader/load.cc
@@ -32,6 +32,10 @@ timetable load(std::vector<std::filesystem::path> const& paths,
   tt.date_range_ = date_range;
   register_special_stations(tt);
 
+  auto global_bitfield_indices =
+      std::make_shared<hash_map<bitfield, bitfield_idx_t>>(
+          hash_map<bitfield, bitfield_idx_t>{});
+
   for (auto const [idx, p] : utl::enumerate(paths)) {
     auto const src = source_idx_t{idx};
     auto const dir = make_dir(p);
@@ -39,7 +43,7 @@ timetable load(std::vector<std::filesystem::path> const& paths,
         utl::find_if(loaders, [&](auto&& l) { return l->applicable(*dir); });
     if (loader_it != end(loaders)) {
       log(log_lvl::info, "loader.load", "loading {}", p.string());
-      (*loader_it)->load(c, src, *dir, tt);
+      (*loader_it)->load(c, src, *dir, tt, global_bitfield_indices);
     } else if (!ignore) {
       throw utl::fail("no loader for {} found", p.string());
     } else {


### PR DESCRIPTION
# deduplicate bitfields globally

experiments on transitous dataset

## serialized timetable file size

**baseline:** 5,2 GB (5.227.994.448 bytes)
**global bitfield indices:** 5,2 GB (5.226.862.608 bytes)
--> saves only ~1MB total file size

## number of bitfields

**baseline:** 135187
**global bitfield indices:** 117502
--> ~13% less bitfields have to be stored

## total time to load timetable

**baseline:** 170025.967ms
**global bitfield indices:** 164905.885ms
--> ~3% shorter loading time