### PR TITLE
increase kMaxTransfers to 15, increase kMaxTravelTime to 5 days

### DIFF
--- a/include/nigiri/routing/limits.h
+++ b/include/nigiri/routing/limits.h
@@ -6,8 +6,8 @@
 
 namespace nigiri::routing {
 
-static constexpr auto const kMaxTransfers = std::uint8_t{7U};
-static constexpr auto const kMaxTravelTime = 1_days;
+static constexpr auto const kMaxTransfers = std::uint8_t{15U};
+static constexpr auto const kMaxTravelTime = 5_days;
 static constexpr auto const kMaxSearchIntervalSize =
     date::days{std::numeric_limits<duration_t::rep>::max() / 1440} -
     (kMaxTravelTime + 2_days);


### PR DESCRIPTION
Greatly improves tail latency for transitous dataset

**Baseline**
```
--- total_time --- (n = 100)
  25%: (t_total:    2.829s, t_exec:    2.656s, intvl_ext:  0, intvl_size:    5h, #jrny:  5)
  50%: (t_total:   10.471s, t_exec:   10.272s, intvl_ext:  1, intvl_size:   15h, #jrny:  7)
  75%: (t_total:   69.797s, t_exec:   69.622s, intvl_ext:  4, intvl_size:  912h, #jrny:  0)
  90%: (t_total:  312.451s, t_exec:  312.270s, intvl_ext:  4, intvl_size:  912h, #jrny:  0)
  99%: (t_total:  605.199s, t_exec:  605.030s, intvl_ext:  4, intvl_size:  912h, #jrny:  0)
99.9%: (t_total:  605.199s, t_exec:  605.030s, intvl_ext:  4, intvl_size:  912h, #jrny:  0)
  max: (t_total:  605.199s, t_exec:  605.030s, intvl_ext:  4, intvl_size:  912h, #jrny:  0)
----------------------------------
```

**5 days, 15 transfers**
```
--- total_time --- (n = 100)
  25%: (t_total:    3.219s, t_exec:    3.083s, intvl_ext:  0, intvl_size:    5h, #jrny:  3)
  50%: (t_total:    6.791s, t_exec:    6.643s, intvl_ext:  0, intvl_size:    5h, #jrny:  7)
  75%: (t_total:   17.490s, t_exec:   17.316s, intvl_ext:  1, intvl_size:   15h, #jrny:  3)
  90%: (t_total:   50.462s, t_exec:   50.256s, intvl_ext:  3, intvl_size:  320h, #jrny: 11)
  99%: (t_total:  469.018s, t_exec:  468.733s, intvl_ext:  4, intvl_size:  720h, #jrny:  0)
99.9%: (t_total:  469.018s, t_exec:  468.733s, intvl_ext:  4, intvl_size:  720h, #jrny:  0)
  max: (t_total:  469.018s, t_exec:  468.733s, intvl_ext:  4, intvl_size:  720h, #jrny:  0)
----------------------------------
```