### PR TITLE
Shortest footpath

### DIFF
--- a/include/nigiri/routing/raptor/reconstruct.h
+++ b/include/nigiri/routing/raptor/reconstruct.h
@@ -23,4 +23,12 @@ void reconstruct_journey(timetable const&,
                          date::sys_days const base,
                          day_idx_t const base_day_idx);
 
+void optimize_footpaths(timetable const&,
+                        rt_timetable const*,
+                        query const&,
+                        raptor_state const&,
+                        journey&,
+                        date::sys_days const base,
+                        day_idx_t const base_day_idx);
+
 }  // namespace nigiri::routing

--- a/include/nigiri/routing/raptor/reconstruct.h
+++ b/include/nigiri/routing/raptor/reconstruct.h
@@ -23,12 +23,6 @@ void reconstruct_journey(timetable const&,
                          date::sys_days const base,
                          day_idx_t const base_day_idx);
 
-void optimize_footpaths(timetable const&,
-                        rt_timetable const*,
-                        query const&,
-                        raptor_state const&,
-                        journey&,
-                        date::sys_days const base,
-                        day_idx_t const base_day_idx);
+void optimize_footpaths(timetable const&, query const&, journey&);
 
 }  // namespace nigiri::routing

--- a/include/nigiri/routing/raptor/reconstruct.h
+++ b/include/nigiri/routing/raptor/reconstruct.h
@@ -23,6 +23,9 @@ void reconstruct_journey(timetable const&,
                          date::sys_days const base,
                          day_idx_t const base_day_idx);
 
-void optimize_footpaths(timetable const&, query const&, journey&);
+void optimize_footpaths(timetable const&,
+                        rt_timetable const*,
+                        query const&,
+                        journey&);
 
 }  // namespace nigiri::routing

--- a/src/routing/raptor/optimize_footpaths.cc
+++ b/src/routing/raptor/optimize_footpaths.cc
@@ -1,21 +1,52 @@
 #include "nigiri/routing/raptor/reconstruct.h"
 
+#include "nigiri/routing/for_each_meta.h"
 #include "nigiri/routing/journey.h"
+#include "nigiri/rt/frun.h"
+#include "nigiri/timetable.h"
 
 namespace nigiri::routing {
 
-void optimize_footpaths(timetable const& tt,
-                        rt_timetable const* rtt,
-                        query const& q,
-                        raptor_state const& raptor_state,
-                        journey& j,
-                        date::sys_days const base,
-                        day_idx_t const base_day_idx) {
-  // optimize start
+void optimize_start(timetable const& tt, query const& q, journey& j) {
+  if (j.legs_.size() <= 1 || !holds_alternative<offset>(j.legs_[0].uses_) ||
+      !holds_alternative<journey::run_enter_exit>(j.legs_[1].uses_)) {
+    return;
+  }
+  auto& offset_leg = j.legs_[0];
+  auto& transport_leg = j.legs_[1];
+  auto& ree = get<journey::run_enter_exit>(transport_leg.uses_);
+  auto offset_dur_best = get<offset>(offset_leg.uses_).duration();
+  for (auto const& o : q.start_) {
+    if (offset_dur_best <= o.duration()) {
+      continue;
+    }
+    auto const stop_seq =
+        tt.route_location_seq_[tt.transport_route_[ree.r_.t_.t_idx_]];
+    for (auto stop_idx = stop_idx_t{0U}; stop_idx != ree.stop_range_.to_;
+         ++stop_idx) {
+      auto stp = stop{stop_seq[stop_idx]};
+      if (!stp.in_allowed() || !matches(tt, location_match_mode::kEquivalent,
+                                        o.target(), stp.location_idx())) {
+        continue;
+      }
+      auto const dep = tt.event_time(ree.r_.t_, stop_idx, event_type::kDep);
+      auto const o_start = dep - o.duration();
+      if (offset_leg.dep_time_ <= o_start) {
+        offset_leg.to_ = stp.location_idx();
+        offset_leg.dep_time_ = o_start;
+        offset_leg.arr_time_ = dep;
+        offset_leg.uses_ = o;
+        transport_leg.from_ = stp.location_idx();
+        transport_leg.dep_time_ = dep;
+        ree.stop_range_.from_ = stop_idx;
+        ree.r_.stop_range_.from_ = stop_idx;
+        offset_dur_best = o.duration();
+      }
+    }
+  }
+}
 
-  // optimize end
-
-  // optimize transfers
+void optimize_transfers(timetable const& tt, query const& q, journey& j) {
   for (auto i = 0U; i != j.legs_.size(); ++i) {
     auto& leg = j.legs_[i];
     if (!holds_alternative<journey::run_enter_exit>(leg.uses_)) {
@@ -23,14 +54,69 @@ void optimize_footpaths(timetable const& tt,
     }
     if (i + 2 < j.legs_.size() &&
         holds_alternative<journey::run_enter_exit>(j.legs_[i + 2].uses_)) {
-      auto& transfer_leg = j.legs_[i + 2];
+      auto& leg_transfer = j.legs_[i + 2];
+      if (matches(tt, location_match_mode::kEquivalent, leg.to_,
+                  leg_transfer.from_)) {
+        continue;
+      }
       auto fp_dur_best = get<footpath>(j.legs_[i + 1].uses_).duration();
-      if (rtt != nullptr) {
-
-      } else {
+      auto& ree = get<journey::run_enter_exit>(leg.uses_);
+      auto& ree_transfer = get<journey::run_enter_exit>(leg_transfer.uses_);
+      auto const stop_seq =
+          tt.route_location_seq_[tt.transport_route_[ree.r_.t_.t_idx_]];
+      for (auto stop_idx = stop_idx_t{0U}; stop_idx != stop_seq.size();
+           ++stop_idx) {
+        auto const stp = stop{stop_seq[stop_idx]};
+        if (!stp.out_allowed()) {
+          continue;
+        }
+        auto const footpaths =
+            tt.locations_.footpaths_out_[q.prf_idx_][stp.location_idx()];
+        for (auto const& fp : footpaths) {
+          if (fp.duration() >= fp_dur_best) {
+            continue;
+          }
+          auto const stop_seq_transfer =
+              tt.route_location_seq_
+                  [tt.transport_route_[ree_transfer.r_.t_.t_idx_]];
+          for (auto stop_idx_transfer = stop_idx_t{0U};
+               stop_idx_transfer != ree_transfer.stop_range_.to_;
+               ++stop_idx_transfer) {
+            auto const stp_transfer =
+                stop{stop_seq_transfer[stop_idx_transfer]};
+            if (!stp_transfer.in_allowed() ||
+                !matches(tt, location_match_mode::kEquivalent, fp.target(),
+                         stp_transfer.location_idx())) {
+              continue;
+            }
+            auto const arr =
+                tt.event_time(ree.r_.t_, stop_idx, event_type::kArr);
+            auto const dep = tt.event_time(ree_transfer.r_.t_,
+                                           stop_idx_transfer, event_type::kDep);
+            if (arr + fp.duration() <= dep) {
+              leg.to_ = stp.location_idx();
+              leg.arr_time_ = arr;
+              ree.stop_range_.to_ = stop_idx;
+              ree.r_.stop_range_.to_ = stop_idx;
+              leg_transfer.from_ = stp_transfer.location_idx();
+              leg_transfer.dep_time_ = dep;
+              ree_transfer.stop_range_.from_ = stop_idx_transfer;
+              ree_transfer.r_.stop_range_.from_ = stop_idx_transfer;
+              fp_dur_best = fp.duration();
+            }
+          }
+        }
       }
     }
   }
+}
+
+void optimize_footpaths(timetable const& tt, query const& q, journey& j) {
+  optimize_start(tt, q, j);
+
+  // optimize end
+
+  optimize_transfers(tt, q, j);
 }
 
 }  // namespace nigiri::routing

--- a/src/routing/raptor/optimize_footpaths.cc
+++ b/src/routing/raptor/optimize_footpaths.cc
@@ -22,10 +22,10 @@ void optimize_start(timetable const& tt, query const& q, journey& j) {
     }
     auto const stop_seq =
         tt.route_location_seq_[tt.transport_route_[ree.r_.t_.t_idx_]];
-    for (auto stop_idx = stop_idx_t{0U}; stop_idx != ree.stop_range_.to_;
+    for (auto stop_idx = stop_idx_t{0U}; stop_idx != ree.stop_range_.to_ - 1U;
          ++stop_idx) {
       auto stp = stop{stop_seq[stop_idx]};
-      if (!stp.in_allowed() || !matches(tt, location_match_mode::kEquivalent,
+      if (!stp.in_allowed() || !matches(tt, location_match_mode::kExact,
                                         o.target(), stp.location_idx())) {
         continue;
       }
@@ -64,7 +64,7 @@ void optimize_end(timetable const& tt, query const& q, journey& j) {
     for (auto stop_idx = static_cast<stop_idx_t>(ree.stop_range_.from_ + 1U);
          stop_idx != stop_seq.size(); ++stop_idx) {
       auto stp = stop{stop_seq[stop_idx]};
-      if (!stp.out_allowed() || !matches(tt, location_match_mode::kEquivalent,
+      if (!stp.out_allowed() || !matches(tt, location_match_mode::kExact,
                                          o.target(), stp.location_idx())) {
         continue;
       }

--- a/src/routing/raptor/optimize_footpaths.cc
+++ b/src/routing/raptor/optimize_footpaths.cc
@@ -1,0 +1,36 @@
+#include "nigiri/routing/raptor/reconstruct.h"
+
+#include "nigiri/routing/journey.h"
+
+namespace nigiri::routing {
+
+void optimize_footpaths(timetable const& tt,
+                        rt_timetable const* rtt,
+                        query const& q,
+                        raptor_state const& raptor_state,
+                        journey& j,
+                        date::sys_days const base,
+                        day_idx_t const base_day_idx) {
+  // optimize start
+
+  // optimize end
+
+  // optimize transfers
+  for (auto i = 0U; i != j.legs_.size(); ++i) {
+    auto& leg = j.legs_[i];
+    if (!holds_alternative<journey::run_enter_exit>(leg.uses_)) {
+      continue;
+    }
+    if (i + 2 < j.legs_.size() &&
+        holds_alternative<journey::run_enter_exit>(j.legs_[i + 2].uses_)) {
+      auto& transfer_leg = j.legs_[i + 2];
+      auto fp_dur_best = get<footpath>(j.legs_[i + 1].uses_).duration();
+      if (rtt != nullptr) {
+
+      } else {
+      }
+    }
+  }
+}
+
+}  // namespace nigiri::routing

--- a/src/routing/raptor/optimize_footpaths.cc
+++ b/src/routing/raptor/optimize_footpaths.cc
@@ -77,8 +77,8 @@ void optimize_end(timetable const& tt, query const& q, journey& j) {
         offset_leg.uses_ = o;
         transport_leg.to_ = stp.location_idx();
         transport_leg.arr_time_ = arr;
-        ree.stop_range_.to_ = stop_idx;
-        ree.r_.stop_range_.to_ = stop_idx;
+        ree.stop_range_.to_ = stop_idx + 1U;
+        ree.r_.stop_range_.to_ = stop_idx + 1U;
         offset_dur_best = o.duration();
       }
     }
@@ -103,8 +103,8 @@ void optimize_transfers(timetable const& tt, query const& q, journey& j) {
       auto& ree_transfer = get<journey::run_enter_exit>(leg_transfer.uses_);
       auto const stop_seq =
           tt.route_location_seq_[tt.transport_route_[ree.r_.t_.t_idx_]];
-      for (auto stop_idx = stop_idx_t{0U}; stop_idx != stop_seq.size();
-           ++stop_idx) {
+      for (auto stop_idx = static_cast<stop_idx_t>(ree.stop_range_.from_ + 1U);
+           stop_idx != stop_seq.size(); ++stop_idx) {
         auto const stp = stop{stop_seq[stop_idx]};
         if (!stp.out_allowed()) {
           continue;
@@ -119,7 +119,7 @@ void optimize_transfers(timetable const& tt, query const& q, journey& j) {
               tt.route_location_seq_
                   [tt.transport_route_[ree_transfer.r_.t_.t_idx_]];
           for (auto stop_idx_transfer = stop_idx_t{0U};
-               stop_idx_transfer != ree_transfer.stop_range_.to_;
+               stop_idx_transfer != ree_transfer.stop_range_.to_ - 1U;
                ++stop_idx_transfer) {
             auto const stp_transfer =
                 stop{stop_seq_transfer[stop_idx_transfer]};
@@ -135,8 +135,8 @@ void optimize_transfers(timetable const& tt, query const& q, journey& j) {
             if (arr + fp.duration() <= dep) {
               leg.to_ = stp.location_idx();
               leg.arr_time_ = arr;
-              ree.stop_range_.to_ = stop_idx;
-              ree.r_.stop_range_.to_ = stop_idx;
+              ree.stop_range_.to_ = stop_idx + 1U;
+              ree.r_.stop_range_.to_ = stop_idx + 1U;
               leg_transfer.from_ = stp_transfer.location_idx();
               leg_transfer.dep_time_ = dep;
               ree_transfer.stop_range_.from_ = stop_idx_transfer;

--- a/src/routing/raptor/optimize_footpaths.cc
+++ b/src/routing/raptor/optimize_footpaths.cc
@@ -39,7 +39,6 @@ void optimize_start(timetable const& tt, query const& q, journey& j) {
         transport_leg.from_ = stp.location_idx();
         transport_leg.dep_time_ = dep;
         ree.stop_range_.from_ = stop_idx;
-        ree.r_.stop_range_.from_ = stop_idx;
         offset_dur_best = o.duration();
       }
     }
@@ -78,7 +77,6 @@ void optimize_end(timetable const& tt, query const& q, journey& j) {
         transport_leg.to_ = stp.location_idx();
         transport_leg.arr_time_ = arr;
         ree.stop_range_.to_ = stop_idx + 1U;
-        ree.r_.stop_range_.to_ = stop_idx + 1U;
         offset_dur_best = o.duration();
       }
     }
@@ -130,22 +128,10 @@ void optimize_transfers(timetable const& tt, query const& q, journey& j) {
           auto const arr_fp = arr + fp.duration();
           auto const dep = tt.event_time(ree_transfer.r_.t_, stop_idx_transfer,
                                          event_type::kDep);
-          std::cout
-              << "Found possible transfer optimization: "
-              << std::string_view{begin(tt.locations_.ids_[stp.location_idx()]),
-                                  end(tt.locations_.ids_[stp.location_idx()])}
-              << " --> "
-              << std::string_view{begin(tt.locations_
-                                            .ids_[stp_transfer.location_idx()]),
-                                  end(tt.locations_
-                                          .ids_[stp_transfer.location_idx()])}
-              << " arr: " << arr << ", arr_fp: " << arr_fp << ", dep: " << dep;
           if (arr_fp <= dep) {
-            std::cout << " | connection reached, using improved transfer\n";
             leg.to_ = stp.location_idx();
             leg.arr_time_ = arr;
             ree.stop_range_.to_ = stop_idx + 1U;
-            ree.r_.stop_range_.to_ = stop_idx + 1U;
             leg_footpath.from_ = stp.location_idx();
             leg_footpath.to_ = stp_transfer.location_idx();
             leg_footpath.dep_time_ = arr;
@@ -154,10 +140,7 @@ void optimize_transfers(timetable const& tt, query const& q, journey& j) {
             leg_transfer.from_ = stp_transfer.location_idx();
             leg_transfer.dep_time_ = dep;
             ree_transfer.stop_range_.from_ = stop_idx_transfer;
-            ree_transfer.r_.stop_range_.from_ = stop_idx_transfer;
             fp_dur_best = fp.duration();
-          } else {
-            std::cout << " | connection not reached\n";
           }
           break;
         }

--- a/src/routing/raptor/optimize_footpaths.cc
+++ b/src/routing/raptor/optimize_footpaths.cc
@@ -3,11 +3,15 @@
 #include "nigiri/routing/for_each_meta.h"
 #include "nigiri/routing/journey.h"
 #include "nigiri/rt/frun.h"
+#include "nigiri/rt/rt_timetable.h"
 #include "nigiri/timetable.h"
 
 namespace nigiri::routing {
 
-void optimize_start(timetable const& tt, query const& q, journey& j) {
+void optimize_start(timetable const& tt,
+                    rt_timetable const* rtt,
+                    query const& q,
+                    journey& j) {
   if (j.legs_.size() <= 1 || !holds_alternative<offset>(j.legs_[0].uses_) ||
       !holds_alternative<journey::run_enter_exit>(j.legs_[1].uses_)) {
     return;
@@ -20,32 +24,50 @@ void optimize_start(timetable const& tt, query const& q, journey& j) {
     if (offset_dur_best <= o.duration()) {
       continue;
     }
-    auto const stop_seq =
-        tt.route_location_seq_[tt.transport_route_[ree.r_.t_.t_idx_]];
-    for (auto stop_idx = stop_idx_t{0U}; stop_idx != ree.stop_range_.to_ - 1U;
-         ++stop_idx) {
-      auto stp = stop{stop_seq[stop_idx]};
-      if (!stp.in_allowed() || !matches(tt, location_match_mode::kExact,
-                                        o.target(), stp.location_idx())) {
-        continue;
+
+    auto const iterate_stops = [&](auto&& stop_seq) {
+      for (auto stop_idx = stop_idx_t{0U}; stop_idx != ree.stop_range_.to_ - 1U;
+           ++stop_idx) {
+        auto stp = stop{stop_seq[stop_idx]};
+        if (!stp.in_allowed() || !matches(tt, location_match_mode::kExact,
+                                          o.target(), stp.location_idx())) {
+          continue;
+        }
+        auto const dep =
+            rtt != nullptr &&
+                    rtt->resolve_rt(ree.r_.t_) != rt_transport_idx_t::invalid()
+                ? rtt->unix_event_time(rtt->resolve_rt(ree.r_.t_), stop_idx,
+                                       event_type::kDep)
+                : tt.event_time(ree.r_.t_, stop_idx, event_type::kDep);
+        auto const o_start = dep - o.duration();
+        if (offset_leg.dep_time_ <= o_start) {
+          offset_leg.to_ = stp.location_idx();
+          offset_leg.dep_time_ = o_start;
+          offset_leg.arr_time_ = dep;
+          offset_leg.uses_ = o;
+          transport_leg.from_ = stp.location_idx();
+          transport_leg.dep_time_ = dep;
+          ree.stop_range_.from_ = stop_idx;
+          offset_dur_best = o.duration();
+        }
       }
-      auto const dep = tt.event_time(ree.r_.t_, stop_idx, event_type::kDep);
-      auto const o_start = dep - o.duration();
-      if (offset_leg.dep_time_ <= o_start) {
-        offset_leg.to_ = stp.location_idx();
-        offset_leg.dep_time_ = o_start;
-        offset_leg.arr_time_ = dep;
-        offset_leg.uses_ = o;
-        transport_leg.from_ = stp.location_idx();
-        transport_leg.dep_time_ = dep;
-        ree.stop_range_.from_ = stop_idx;
-        offset_dur_best = o.duration();
-      }
+    };
+
+    if (rtt != nullptr &&
+        rtt->resolve_rt(ree.r_.t_) != rt_transport_idx_t::invalid()) {
+      iterate_stops(
+          rtt->rt_transport_location_seq_[rtt->resolve_rt(ree.r_.t_)]);
+    } else {
+      iterate_stops(
+          tt.route_location_seq_[tt.transport_route_[ree.r_.t_.t_idx_]]);
     }
   }
 }
 
-void optimize_end(timetable const& tt, query const& q, journey& j) {
+void optimize_end(timetable const& tt,
+                  rt_timetable const* rtt,
+                  query const& q,
+                  journey& j) {
   if (j.legs_.size() <= 1 || !holds_alternative<offset>(j.legs_.back().uses_) ||
       !holds_alternative<journey::run_enter_exit>(rbegin(j.legs_)[1].uses_)) {
     return;
@@ -58,32 +80,50 @@ void optimize_end(timetable const& tt, query const& q, journey& j) {
     if (offset_dur_best <= o.duration()) {
       continue;
     }
-    auto const stop_seq =
-        tt.route_location_seq_[tt.transport_route_[ree.r_.t_.t_idx_]];
-    for (auto stop_idx = static_cast<stop_idx_t>(ree.stop_range_.from_ + 1U);
-         stop_idx != stop_seq.size(); ++stop_idx) {
-      auto stp = stop{stop_seq[stop_idx]};
-      if (!stp.out_allowed() || !matches(tt, location_match_mode::kExact,
-                                         o.target(), stp.location_idx())) {
-        continue;
+
+    auto const iterate_stops = [&](auto&& stop_seq) {
+      for (auto stop_idx = static_cast<stop_idx_t>(ree.stop_range_.from_ + 1U);
+           stop_idx != stop_seq.size(); ++stop_idx) {
+        auto stp = stop{stop_seq[stop_idx]};
+        if (!stp.out_allowed() || !matches(tt, location_match_mode::kExact,
+                                           o.target(), stp.location_idx())) {
+          continue;
+        }
+        auto const arr =
+            rtt != nullptr &&
+                    rtt->resolve_rt(ree.r_.t_) != rt_transport_idx_t::invalid()
+                ? rtt->unix_event_time(rtt->resolve_rt(ree.r_.t_), stop_idx,
+                                       event_type::kArr)
+                : tt.event_time(ree.r_.t_, stop_idx, event_type::kArr);
+        auto const o_end = arr + o.duration();
+        if (o_end <= offset_leg.arr_time_) {
+          offset_leg.from_ = stp.location_idx();
+          offset_leg.dep_time_ = arr;
+          offset_leg.arr_time_ = o_end;
+          offset_leg.uses_ = o;
+          transport_leg.to_ = stp.location_idx();
+          transport_leg.arr_time_ = arr;
+          ree.stop_range_.to_ = stop_idx + 1U;
+          offset_dur_best = o.duration();
+        }
       }
-      auto const arr = tt.event_time(ree.r_.t_, stop_idx, event_type::kArr);
-      auto const o_end = arr + o.duration();
-      if (o_end <= offset_leg.arr_time_) {
-        offset_leg.from_ = stp.location_idx();
-        offset_leg.dep_time_ = arr;
-        offset_leg.arr_time_ = o_end;
-        offset_leg.uses_ = o;
-        transport_leg.to_ = stp.location_idx();
-        transport_leg.arr_time_ = arr;
-        ree.stop_range_.to_ = stop_idx + 1U;
-        offset_dur_best = o.duration();
-      }
+    };
+
+    if (rtt != nullptr &&
+        rtt->resolve_rt(ree.r_.t_) != rt_transport_idx_t::invalid()) {
+      iterate_stops(
+          rtt->rt_transport_location_seq_[rtt->resolve_rt(ree.r_.t_)]);
+    } else {
+      iterate_stops(
+          tt.route_location_seq_[tt.transport_route_[ree.r_.t_.t_idx_]]);
     }
   }
 }
 
-void optimize_transfers(timetable const& tt, query const& q, journey& j) {
+void optimize_transfers(timetable const& tt,
+                        rt_timetable const* rtt,
+                        query const& q,
+                        journey& j) {
   for (auto i = 0U; i + 2 < j.legs_.size(); ++i) {
     auto& leg = j.legs_[i];
     auto& leg_footpath = j.legs_[i + 1];
@@ -98,61 +138,97 @@ void optimize_transfers(timetable const& tt, query const& q, journey& j) {
     auto fp_dur_best = get<footpath>(leg_footpath.uses_).duration();
     auto& ree = get<journey::run_enter_exit>(leg.uses_);
     auto& ree_transfer = get<journey::run_enter_exit>(leg_transfer.uses_);
-    auto const stop_seq =
-        tt.route_location_seq_[tt.transport_route_[ree.r_.t_.t_idx_]];
-    for (auto stop_idx = static_cast<stop_idx_t>(ree.stop_range_.from_ + 1U);
-         stop_idx != stop_seq.size(); ++stop_idx) {
-      auto const stp = stop{stop_seq[stop_idx]};
-      if (!stp.out_allowed()) {
-        continue;
-      }
-      auto const footpaths =
-          tt.locations_.footpaths_out_[q.prf_idx_][stp.location_idx()];
-      for (auto const& fp : footpaths) {
-        if (fp.duration() >= fp_dur_best) {
+
+    auto const iterate_stops = [&](auto&& stop_seq) {
+      for (auto stop_idx = static_cast<stop_idx_t>(ree.stop_range_.from_ + 1U);
+           stop_idx != stop_seq.size(); ++stop_idx) {
+        auto const stp = stop{stop_seq[stop_idx]};
+        if (!stp.out_allowed()) {
           continue;
         }
-        auto const stop_seq_transfer =
-            tt.route_location_seq_
-                [tt.transport_route_[ree_transfer.r_.t_.t_idx_]];
-        for (auto stop_idx_transfer = stop_idx_t{0U};
-             stop_idx_transfer != ree_transfer.stop_range_.to_ - 1U;
-             ++stop_idx_transfer) {
-          auto const stp_transfer = stop{stop_seq_transfer[stop_idx_transfer]};
-          if (!stp_transfer.in_allowed() ||
-              !matches(tt, location_match_mode::kExact, fp.target(),
-                       stp_transfer.location_idx())) {
+        auto const footpaths =
+            tt.locations_.footpaths_out_[q.prf_idx_][stp.location_idx()];
+        for (auto const& fp : footpaths) {
+          if (fp.duration() >= fp_dur_best) {
             continue;
           }
-          auto const arr = tt.event_time(ree.r_.t_, stop_idx, event_type::kArr);
-          auto const arr_fp = arr + fp.duration();
-          auto const dep = tt.event_time(ree_transfer.r_.t_, stop_idx_transfer,
-                                         event_type::kDep);
-          if (arr_fp <= dep) {
-            leg.to_ = stp.location_idx();
-            leg.arr_time_ = arr;
-            ree.stop_range_.to_ = stop_idx + 1U;
-            leg_footpath.from_ = stp.location_idx();
-            leg_footpath.to_ = stp_transfer.location_idx();
-            leg_footpath.dep_time_ = arr;
-            leg_footpath.arr_time_ = arr_fp;
-            leg_footpath.uses_ = fp;
-            leg_transfer.from_ = stp_transfer.location_idx();
-            leg_transfer.dep_time_ = dep;
-            ree_transfer.stop_range_.from_ = stop_idx_transfer;
-            fp_dur_best = fp.duration();
+
+          auto const iterate_stops_transfer = [&](auto&& stop_seq_transfer) {
+            for (auto stop_idx_transfer = stop_idx_t{0U};
+                 stop_idx_transfer != ree_transfer.stop_range_.to_ - 1U;
+                 ++stop_idx_transfer) {
+              auto const stp_transfer =
+                  stop{stop_seq_transfer[stop_idx_transfer]};
+              if (!stp_transfer.in_allowed() ||
+                  !matches(tt, location_match_mode::kExact, fp.target(),
+                           stp_transfer.location_idx())) {
+                continue;
+              }
+              auto const arr =
+                  rtt != nullptr && rtt->resolve_rt(ree.r_.t_) !=
+                                        rt_transport_idx_t::invalid()
+                      ? rtt->unix_event_time(rtt->resolve_rt(ree.r_.t_),
+                                             stop_idx, event_type::kArr)
+                      : tt.event_time(ree.r_.t_, stop_idx, event_type::kArr);
+              auto const arr_fp = arr + fp.duration();
+              auto const dep =
+                  rtt != nullptr && rtt->resolve_rt(ree_transfer.r_.t_) !=
+                                        rt_transport_idx_t::invalid()
+                      ? rtt->unix_event_time(
+                            rtt->resolve_rt(ree_transfer.r_.t_),
+                            stop_idx_transfer, event_type::kDep)
+                      : tt.event_time(ree_transfer.r_.t_, stop_idx_transfer,
+                                      event_type::kDep);
+              if (arr_fp <= dep) {
+                leg.to_ = stp.location_idx();
+                leg.arr_time_ = arr;
+                ree.stop_range_.to_ = stop_idx + 1U;
+                leg_footpath.from_ = stp.location_idx();
+                leg_footpath.to_ = stp_transfer.location_idx();
+                leg_footpath.dep_time_ = arr;
+                leg_footpath.arr_time_ = arr_fp;
+                leg_footpath.uses_ = fp;
+                leg_transfer.from_ = stp_transfer.location_idx();
+                leg_transfer.dep_time_ = dep;
+                ree_transfer.stop_range_.from_ = stop_idx_transfer;
+                fp_dur_best = fp.duration();
+              }
+              break;
+            }
+          };
+
+          if (rtt != nullptr && rtt->resolve_rt(ree_transfer.r_.t_) !=
+                                    rt_transport_idx_t::invalid()) {
+            iterate_stops_transfer(
+                rtt->rt_transport_location_seq_[rtt->resolve_rt(
+                    ree_transfer.r_.t_)]);
+          } else {
+            iterate_stops_transfer(
+                tt.route_location_seq_
+                    [tt.transport_route_[ree_transfer.r_.t_.t_idx_]]);
           }
-          break;
         }
       }
+    };
+
+    if (rtt != nullptr &&
+        rtt->resolve_rt(ree.r_.t_) != rt_transport_idx_t::invalid()) {
+      iterate_stops(
+          rtt->rt_transport_location_seq_[rtt->resolve_rt(ree.r_.t_)]);
+    } else {
+      iterate_stops(
+          tt.route_location_seq_[tt.transport_route_[ree.r_.t_.t_idx_]]);
     }
   }
 }
 
-void optimize_footpaths(timetable const& tt, query const& q, journey& j) {
-  optimize_start(tt, q, j);
-  optimize_end(tt, q, j);
-  optimize_transfers(tt, q, j);
+void optimize_footpaths(timetable const& tt,
+                        rt_timetable const* rtt,
+                        query const& q,
+                        journey& j) {
+  optimize_start(tt, rtt, q, j);
+  optimize_end(tt, rtt, q, j);
+  optimize_transfers(tt, rtt, q, j);
 }
 
 }  // namespace nigiri::routing

--- a/src/routing/raptor/optimize_footpaths.cc
+++ b/src/routing/raptor/optimize_footpaths.cc
@@ -124,7 +124,7 @@ void optimize_transfers(timetable const& tt, query const& q, journey& j) {
             auto const stp_transfer =
                 stop{stop_seq_transfer[stop_idx_transfer]};
             if (!stp_transfer.in_allowed() ||
-                !matches(tt, location_match_mode::kEquivalent, fp.target(),
+                !matches(tt, location_match_mode::kExact, fp.target(),
                          stp_transfer.location_idx())) {
               continue;
             }

--- a/src/routing/raptor/reconstruct.cc
+++ b/src/routing/raptor/reconstruct.cc
@@ -383,15 +383,11 @@ void reconstruct_journey(timetable const& tt,
         std::optional<std::pair<journey::leg, journey::leg>>{std::nullopt};
     for (auto const& fp : footpaths) {
       auto fp_legs = check_fp(k, l, curr_time, fp);
-      if (fp_legs.has_value()) {
-        if (fp_legs_best.has_value()) {
-          if (get<footpath>(fp_legs.value().first.uses_).duration() <
-              get<footpath>(fp_legs_best.value().first.uses_).duration()) {
-            fp_legs_best = fp_legs;
-          }
-        } else {
-          fp_legs_best = fp_legs;
-        }
+      if (fp_legs.has_value() &&
+          (!fp_legs_best.has_value() ||
+           get<footpath>(fp_legs.value().first.uses_).duration() <
+               get<footpath>(fp_legs_best.value().first.uses_).duration())) {
+        fp_legs_best = std::move(fp_legs);
       }
     }
 

--- a/src/routing/raptor/reconstruct.cc
+++ b/src/routing/raptor/reconstruct.cc
@@ -401,6 +401,8 @@ void reconstruct_journey(timetable const& tt,
     std::reverse(begin(j.legs_), end(j.legs_));
   }
 
+  optimize_footpaths(tt, q, j);
+
 #if defined(NIGIRI_TRACE_RECUSTRUCT)
   j.print(std::cout, tt, true);
 #endif

--- a/src/routing/raptor/reconstruct.cc
+++ b/src/routing/raptor/reconstruct.cc
@@ -401,7 +401,7 @@ void reconstruct_journey(timetable const& tt,
     std::reverse(begin(j.legs_), end(j.legs_));
   }
 
-  optimize_footpaths(tt, q, j);
+  optimize_footpaths(tt, rtt, q, j);
 
 #if defined(NIGIRI_TRACE_RECUSTRUCT)
   j.print(std::cout, tt, true);

--- a/src/routing/raptor/reconstruct.cc
+++ b/src/routing/raptor/reconstruct.cc
@@ -418,7 +418,7 @@ void reconstruct_journey(timetable const& tt,
     std::reverse(begin(j.legs_), end(j.legs_));
   }
 
-  optimize_footpaths(tt, rtt, q, raptor_state, j, base, base_day_idx);
+  optimize_footpaths(tt, q, j);
 
 #if defined(NIGIRI_TRACE_RECUSTRUCT)
   j.print(std::cout, tt, true);

--- a/src/routing/raptor/reconstruct.cc
+++ b/src/routing/raptor/reconstruct.cc
@@ -315,18 +315,14 @@ void reconstruct_journey(timetable const& tt,
     if (q.dest_match_mode_ == location_match_mode::kIntermodal &&
         k == j.transfers_ + 1U) {
       trace_reconstruct("  CHECKING INTERMODAL DEST\n");
-      std::optional<std::pair<journey::leg, journey::leg>> ret;
       for (auto const& dest_offset : q.destination_) {
+        std::optional<std::pair<journey::leg, journey::leg>> ret;
         for_each_meta(
             tt, location_match_mode::kIntermodal, dest_offset.target_,
             [&](location_idx_t const eq) {
               auto intermodal_dest =
                   check_fp(k, l, curr_time, {eq, dest_offset.duration_});
-              if (intermodal_dest.has_value() &&
-                  (!ret.has_value() ||
-                   get<footpath>(intermodal_dest.value().first.uses_)
-                           .duration() <
-                       get<offset>(ret.value().first.uses_).duration())) {
+              if (intermodal_dest.has_value()) {
                 trace_rc_intermodal_dest_match;
                 intermodal_dest->first.uses_ = offset{
                     eq, dest_offset.duration_, dest_offset.transport_mode_id_};
@@ -341,11 +337,7 @@ void reconstruct_journey(timetable const& tt,
                 auto fp_intermodal_dest = check_fp(
                     k, l, curr_time,
                     {fp.target(), dest_offset.duration_ + fp.duration()});
-                if (fp_intermodal_dest.has_value() &&
-                    (!ret.has_value() ||
-                     get<footpath>(fp_intermodal_dest.value().first.uses_)
-                             .duration() <
-                         get<offset>(ret.value().first.uses_).duration())) {
+                if (fp_intermodal_dest.has_value()) {
                   trace_rc_fp_intermodal_dest_match;
                   fp_intermodal_dest->first.uses_ =
                       offset{eq, fp.duration(), dest_offset.transport_mode_id_};
@@ -355,9 +347,9 @@ void reconstruct_journey(timetable const& tt,
                 }
               }
             });
-      }
-      if (ret.has_value()) {
-        return std::move(*ret);
+        if (ret.has_value()) {
+          return std::move(*ret);
+        }
       }
 
       throw utl::fail(
@@ -379,20 +371,11 @@ void reconstruct_journey(timetable const& tt,
     trace_reconstruct("CHECKING FOOTPATHS OF {}\n", location{tt, l});
     auto const footpaths = kFwd ? tt.locations_.footpaths_in_[q.prf_idx_][l]
                                 : tt.locations_.footpaths_out_[q.prf_idx_][l];
-    auto fp_legs_best =
-        std::optional<std::pair<journey::leg, journey::leg>>{std::nullopt};
     for (auto const& fp : footpaths) {
       auto fp_legs = check_fp(k, l, curr_time, fp);
-      if (fp_legs.has_value() &&
-          (!fp_legs_best.has_value() ||
-           get<footpath>(fp_legs.value().first.uses_).duration() <
-               get<footpath>(fp_legs_best.value().first.uses_).duration())) {
-        fp_legs_best = std::move(fp_legs);
+      if (fp_legs.has_value()) {
+        return std::move(*fp_legs);
       }
-    }
-
-    if (fp_legs_best.has_value()) {
-      return std::move(*fp_legs_best);
     }
 
     throw utl::fail("reconstruction failed at k={}, t={}, stop={}, time={}", k,
@@ -417,8 +400,6 @@ void reconstruct_journey(timetable const& tt,
   if constexpr (kFwd) {
     std::reverse(begin(j.legs_), end(j.legs_));
   }
-
-  optimize_footpaths(tt, q, j);
 
 #if defined(NIGIRI_TRACE_RECUSTRUCT)
   j.print(std::cout, tt, true);

--- a/src/routing/raptor/reconstruct.cc
+++ b/src/routing/raptor/reconstruct.cc
@@ -418,6 +418,8 @@ void reconstruct_journey(timetable const& tt,
     std::reverse(begin(j.legs_), end(j.legs_));
   }
 
+  optimize_footpaths(tt, rtt, q, raptor_state, j, base, base_day_idx);
+
 #if defined(NIGIRI_TRACE_RECUSTRUCT)
   j.print(std::cout, tt, true);
 #endif


### PR DESCRIPTION
Adds a postprocessing step after reconstruction. 

- Tries to replace the start station with a station that has a departure of the same transport as the first transport leg of the journey but is reachable from the START coordinate by a shorter footpath
- Tries to replace the end station with a station that has an arrvial of the same transport as the last transport leg of the journey but reaches the END coordinate with a shorter footpath
- For each transfer tries to find a shorter footpath that allows to transfer between the two transports involved