### PR TITLE
Add transfer time settings for routing (with LB)

### DIFF
--- a/include/nigiri/lb_entry.h
+++ b/include/nigiri/lb_entry.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <algorithm>
+
+#include "cista/reflection/comparable.h"
+
+#include "nigiri/routing/transfer_time_settings.h"
+#include "nigiri/types.h"
+
+namespace nigiri {
+
+struct lb_entry {
+  CISTA_COMPARABLE()
+
+  static constexpr auto const kUnreachable =
+      duration_t{std::numeric_limits<duration_t::rep>::max()};
+
+  location_idx_t target() const { return target_; }
+
+  duration_t duration(routing::transfer_time_settings const& tts) const {
+    if (footpath_duration_ == kUnreachable) {
+      return trip_duration_;
+    } else {
+      return std::min(routing::adjusted_transfer_time(tts, footpath_duration_),
+                      trip_duration_);
+    }
+  }
+
+  duration_t footpath_duration() const { return footpath_duration_; }
+  duration_t trip_duration() const { return trip_duration_; }
+
+  location_idx_t target_{};
+  duration_t footpath_duration_{};
+  duration_t trip_duration_{};
+};
+
+}  // namespace nigiri

--- a/include/nigiri/loader/build_lb_graph.h
+++ b/include/nigiri/loader/build_lb_graph.h
@@ -100,7 +100,9 @@ void build_lb_graph(timetable& tt, profile_idx_t const prf_idx = 0) {
     add_edges(i);
 
     for (auto const& [target, duration] : weights) {
-      entries.emplace_back(target, duration.first, duration.second);
+      entries.emplace_back(lb_entry{.target_ = target,
+                                    .footpath_duration_ = duration.first,
+                                    .trip_duration_ = duration.second});
     }
 
     lb_graph.emplace_back(entries);

--- a/include/nigiri/routing/dijkstra.h
+++ b/include/nigiri/routing/dijkstra.h
@@ -3,7 +3,7 @@
 #include "fmt/ranges.h"
 
 #include "nigiri/common/dial.h"
-#include "nigiri/footpath.h"
+#include "nigiri/lb_entry.h"
 #include "nigiri/types.h"
 
 namespace nigiri {
@@ -58,7 +58,7 @@ void dijkstra(vecvec<NodeIdx, Edge> const& graph,
 
 void dijkstra(timetable const&,
               query const&,
-              vecvec<location_idx_t, footpath> const& lb_graph,
+              vecvec<location_idx_t, lb_entry> const& lb_graph,
               std::vector<std::uint16_t>& dists);
 
 }  // namespace nigiri::routing

--- a/include/nigiri/routing/query.h
+++ b/include/nigiri/routing/query.h
@@ -10,6 +10,7 @@
 #include "nigiri/routing/clasz_mask.h"
 #include "nigiri/routing/limits.h"
 #include "nigiri/routing/location_match_mode.h"
+#include "nigiri/routing/transfer_time_settings.h"
 #include "nigiri/types.h"
 
 namespace nigiri::routing {
@@ -55,6 +56,7 @@ struct query {
   profile_idx_t prf_idx_{0};
   clasz_mask_t allowed_claszes_{all_clasz_allowed()};
   bool require_bike_transport_{false};
+  transfer_time_settings transfer_time_settings_{};
 };
 
 }  // namespace nigiri::routing

--- a/include/nigiri/routing/raptor/debug.h
+++ b/include/nigiri/routing/raptor/debug.h
@@ -78,7 +78,8 @@
       "    --> start: FP+INTERMODAL START -> {}  leg_start_time={}, "        \
       "j_start_time={}, offset={}, footpath=({}, {})\n",                     \
       location{tt, o.target()}, leg_start_time, j.start_time_, o.duration(), \
-      fp.duration(), location{tt, fp.target()})
+      adjusted_transfer_time(q.transfer_time_settings_, fp.duration()),      \
+      location{tt, fp.target()})
 
 #define trace_rc_intermodal_fp_no_match                                        \
   trace_reconstruct(                                                           \
@@ -88,14 +89,17 @@
       location{tt, o.target()},                                                \
       matches(tt, q.start_match_mode_, o.target(), leg_start_location),        \
       location{tt, leg_start_location}, leg_start_time, j.start_time_,         \
-      o.duration(), fp.duration(), location{tt, fp.target()})
+      o.duration(),                                                            \
+      adjusted_transfer_time(q.transfer_time_settings_, fp.duration()),        \
+      location{tt, fp.target()})
 
 #define trace_rc_fp_start_found                                            \
   trace_reconstruct(                                                       \
       "    --> from={}, j_start={}, journey_start={}, fp_target_time={}, " \
       "duration={}\n",                                                     \
       location{tt, fp.target()}, location{tt, leg_start_location},         \
-      j.start_time_, fp_target_time, fp.duration())
+      j.start_time_, fp_target_time,                                       \
+      adjusted_transfer_time(q.transfer_time_settings_, fp.duration()))
 
 #define trace_rc_fp_start_no_match                                        \
   trace_reconstruct(                                                      \
@@ -103,7 +107,8 @@
       "fp_start_time={}, j_start_time={}, fp_duration={}\n",              \
       location{tt, fp.target()}, location{tt, leg_start_location},        \
       is_journey_start(tt, q, fp.target()), fp_target_time, j_start_time, \
-      fp.duration().count())
+      adjusted_transfer_time(q.transfer_time_settings_,                   \
+                             fp.duration().count()))
 
 #define trace_rc_transport                                                    \
   trace_reconstruct(                                                          \
@@ -145,7 +150,8 @@
       "  BAD intermodal+footpath dest offset: {}@{} --{}--> "           \
       "{}@{} --{}--> END@{} (type={})\n",                               \
       location{tt, fp.target()},                                        \
-      raptor_state.round_times_[k][to_idx(fp.target())], fp.duration(), \
+      raptor_state.round_times_[k][to_idx(fp.target())],                \
+      adjusted_transfer_time(q.transfer_time_settings_, fp.duration()), \
       location{tt, eq}, raptor_state.round_times_[k][to_idx(eq)],       \
       dest_offset.duration_, curr_time, dest_offset.type())
 
@@ -153,7 +159,8 @@
   trace_reconstruct(                                             \
       "  found intermodal+footpath dest offset END [{}] -> {}: " \
       "offset={}\n",                                             \
-      curr_time, location{tt, fp.target()}, fp.duration())
+      curr_time, location{tt, fp.target()},                      \
+      adjusted_transfer_time(q.transfer_time_settings_, fp.duration()))
 
 #define trace_rc_intermodal_dest_mismatch                                 \
   trace_reconstruct("  BAD intermodal dest offset: END [{}] -> {}: {}\n", \
@@ -166,19 +173,22 @@
       "offset={}\n",                                    \
       curr_time, location{tt, dest_offset.target_}, dest_offset.duration_)
 
-#define trace_rc_legs_found                                            \
-  trace_reconstruct("found:\n");                                       \
-  transport_leg->print(std::cout, tt, rtt, 1, true);                   \
-  trace_reconstruct(" fp leg: {} {} --{}--> {} {}\n", location{tt, l}, \
-                    delta_to_unix(base, fp_start), fp.duration(),      \
-                    location{tt, fp.target()}, delta_to_unix(base, curr_time))
+#define trace_rc_legs_found                                             \
+  trace_reconstruct("found:\n");                                        \
+  transport_leg->print(std::cout, tt, rtt, 1, true);                    \
+  trace_reconstruct(                                                    \
+      " fp leg: {} {} --{}--> {} {}\n", location{tt, l},                \
+      delta_to_unix(base, fp_start),                                    \
+      adjusted_transfer_time(q.transfer_time_settings_, fp.duration()), \
+      location{tt, fp.target()}, delta_to_unix(base, curr_time))
 
 #define trace_rc_check_fp                                                   \
   trace_reconstruct(                                                        \
       "round {}: searching for transports at {} with curr_time={} --{}--> " \
       "fp_start={}\n ",                                                     \
       k, location{tt, fp.target()}, delta_to_unix(base, curr_time),         \
-      fp.duration(), delta_to_unix(base, fp_start))
+      adjusted_transfer_time(q.transfer_time_settings_, fp.duration()),     \
+      delta_to_unix(base, fp_start))
 
 #else
 #define trace_reconstruct(...)

--- a/include/nigiri/routing/search.h
+++ b/include/nigiri/routing/search.h
@@ -328,7 +328,7 @@ private:
     state_.starts_.reserve(500'000);
     get_starts(SearchDir, tt_, rtt_, start_interval, q_.start_,
                q_.start_match_mode_, q_.use_start_footpaths_, state_.starts_,
-               add_ontrip, q_.prf_idx_);
+               add_ontrip, q_.prf_idx_, q_.transfer_time_settings_);
     std::sort(
         begin(state_.starts_), end(state_.starts_),
         [&](start const& a, start const& b) { return kFwd ? b < a : a < b; });

--- a/include/nigiri/routing/search.h
+++ b/include/nigiri/routing/search.h
@@ -58,6 +58,7 @@ struct search {
 
   Algo init(clasz_mask_t const allowed_claszes,
             bool const require_bikes_allowed,
+            transfer_time_settings const& tts,
             algo_state_t& algo_state) {
     stats_.fastest_direct_ =
         static_cast<std::uint64_t>(fastest_direct_.count());
@@ -111,7 +112,8 @@ struct search {
                 tt_.internal_interval().from_)
                 .count()},
         allowed_claszes,
-        require_bikes_allowed};
+        require_bikes_allowed,
+        tts};
   }
 
   search(timetable const& tt,
@@ -134,8 +136,11 @@ struct search {
                 }},
             q_.start_time_)},
         fastest_direct_{get_fastest_direct(tt_, q_, SearchDir)},
-        algo_{
-            init(q_.allowed_claszes_, q_.require_bike_transport_, algo_state)},
+
+        algo_{init(q_.allowed_claszes_,
+                   q_.require_bike_transport_,
+                   q.transfer_time_settings_,
+                   algo_state)},
         timeout_(timeout) {
     utl::sort(q.start_);
     utl::sort(q.destination_);

--- a/include/nigiri/routing/start_times.h
+++ b/include/nigiri/routing/start_times.h
@@ -32,7 +32,8 @@ void get_starts(direction,
                 bool use_start_footpaths,
                 std::vector<start>&,
                 bool add_ontrip,
-                profile_idx_t);
+                profile_idx_t,
+                transfer_time_settings const&);
 
 void collect_destinations(timetable const&,
                           std::vector<offset> const& destinations,

--- a/include/nigiri/routing/transfer_time_settings.h
+++ b/include/nigiri/routing/transfer_time_settings.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "nigiri/types.h"
+
+namespace nigiri::routing {
+
+struct transfer_time_settings {
+  bool default_{true};
+  duration_t min_transfer_time_{0};
+  float factor_{1.0F};
+};
+
+template <typename T>
+inline T adjusted_transfer_time(transfer_time_settings const& settings,
+                                T const duration) {
+  if (settings.default_) {
+    return duration;
+  } else {
+    return std::max(
+        static_cast<T>(settings.min_transfer_time_.count()),
+        static_cast<T>(static_cast<float>(duration) * settings.factor_));
+  }
+}
+
+template <typename Rep>
+inline std::chrono::duration<Rep, std::ratio<60>> adjusted_transfer_time(
+    transfer_time_settings const& settings,
+    std::chrono::duration<Rep, std::ratio<60>> const duration) {
+  if (settings.default_) {
+    return duration;
+  } else {
+    return std::chrono::duration<Rep, std::ratio<60>>{
+        std::max(static_cast<Rep>(settings.min_transfer_time_.count()),
+                 static_cast<Rep>(static_cast<float>(duration.count()) *
+                                  settings.factor_))};
+  }
+}
+
+}  // namespace nigiri::routing

--- a/include/nigiri/routing/transfer_time_settings.h
+++ b/include/nigiri/routing/transfer_time_settings.h
@@ -5,6 +5,12 @@
 namespace nigiri::routing {
 
 struct transfer_time_settings {
+  bool operator==(transfer_time_settings const& o) const {
+    return default_ == o.default_ ||
+           std::tie(min_transfer_time_, factor_) ==
+               std::tie(o.min_transfer_time_, o.factor_);
+  }
+
   bool default_{true};
   duration_t min_transfer_time_{0};
   float factor_{1.0F};

--- a/include/nigiri/timetable.h
+++ b/include/nigiri/timetable.h
@@ -15,6 +15,7 @@
 
 #include "nigiri/common/interval.h"
 #include "nigiri/footpath.h"
+#include "nigiri/lb_entry.h"
 #include "nigiri/location.h"
 #include "nigiri/logging.h"
 #include "nigiri/stop.h"
@@ -474,8 +475,8 @@ struct timetable {
   vecvec<transport_idx_t, route_color> transport_section_route_colors_;
 
   // Lower bound graph.
-  vecvec<location_idx_t, footpath> fwd_search_lb_graph_;
-  vecvec<location_idx_t, footpath> bwd_search_lb_graph_;
+  vecvec<location_idx_t, lb_entry> fwd_search_lb_graph_;
+  vecvec<location_idx_t, lb_entry> bwd_search_lb_graph_;
 
   // profile name -> profile_idx_t
   hash_map<string, profile_idx_t> profiles_;

--- a/include/nigiri/types.h
+++ b/include/nigiri/types.h
@@ -226,7 +226,7 @@ using duration_t = i16_minutes;
 using unixtime_t = std::chrono::sys_time<i32_minutes>;
 using local_time = date::local_time<i32_minutes>;
 
-constexpr u8_minutes operator""_i8_minutes(unsigned long long n) {
+constexpr u8_minutes operator""_u8_minutes(unsigned long long n) {
   return duration_t{n};
 }
 

--- a/src/routing/dijkstra.cc
+++ b/src/routing/dijkstra.cc
@@ -5,7 +5,7 @@
 #include "utl/get_or_create.h"
 
 #include "nigiri/common/dial.h"
-#include "nigiri/footpath.h"
+#include "nigiri/lb_entry.h"
 #include "nigiri/routing/for_each_meta.h"
 #include "nigiri/routing/limits.h"
 #include "nigiri/routing/query.h"
@@ -20,9 +20,38 @@
 
 namespace nigiri::routing {
 
+template <typename Label, typename GetBucketFn>
+void dijkstra(vecvec<location_idx_t, lb_entry> const& graph,
+              dial<Label, GetBucketFn>& pq,
+              transfer_time_settings const& tts,
+              std::vector<typename Label::dist_t>& dists,
+              typename Label::dist_t const max_dist =
+                  std::numeric_limits<typename Label::dist_t>::max()) {
+  using dist_t = typename Label::dist_t;
+
+  while (!pq.empty()) {
+    auto l = pq.top();
+    pq.pop();
+
+    if (dists[cista::to_idx(l.l_)] < l.d_) {
+      continue;
+    }
+
+    for (auto const& e : graph[l.l_]) {
+      auto const edge_target = cista::to_idx(e.target());
+      auto const new_dist = l.d_ + e.duration(tts).count();
+      if (new_dist < dists[edge_target] && new_dist < pq.n_buckets() &&
+          new_dist < max_dist) {
+        dists[edge_target] = static_cast<dist_t>(new_dist);
+        pq.push(Label{e.target(), static_cast<dist_t>(new_dist)});
+      }
+    }
+  }
+}
+
 void dijkstra(timetable const& tt,
               query const& q,
-              vecvec<location_idx_t, footpath> const& lb_graph,
+              vecvec<location_idx_t, lb_entry> const& lb_graph,
               std::vector<label::dist_t>& dists) {
   dists.resize(tt.n_locations());
   utl::fill(dists, std::numeric_limits<label::dist_t>::max());
@@ -49,7 +78,7 @@ void dijkstra(timetable const& tt,
     });
   }
 
-  dijkstra(lb_graph, pq, dists);
+  dijkstra(lb_graph, pq, q.transfer_time_settings_, dists);
 }
 
 }  // namespace nigiri::routing

--- a/src/routing/get_fastest_direct.cc
+++ b/src/routing/get_fastest_direct.cc
@@ -61,7 +61,9 @@ duration_t get_fastest_direct(timetable const& tt,
                                     : tt.locations_.footpaths_in_[q.prf_idx_]);
     for (auto const& fp : footpaths[l.l_]) {
       auto const new_dist =
-          l.d_ + static_cast<label::dist_t>(fp.duration().count());
+          l.d_ + adjusted_transfer_time(
+                     q.transfer_time_settings_,
+                     static_cast<label::dist_t>(fp.duration().count()));
       if (new_dist > max_dist) {
         continue;
       }

--- a/src/routing/raptor/optimize_footpaths.cc
+++ b/src/routing/raptor/optimize_footpaths.cc
@@ -119,7 +119,9 @@ void optimize_transfers(timetable const& tt,
       continue;
     }
 
-    auto fp_dur_best = get<footpath>(leg_footpath.uses_).duration();
+    auto fp_dur_best =
+        adjusted_transfer_time(q.transfer_time_settings_,
+                               get<footpath>(leg_footpath.uses_).duration());
     auto& ree_from = get<journey::run_enter_exit>(leg_from.uses_);
     auto& ree_to = get<journey::run_enter_exit>(leg_to.uses_);
 
@@ -141,13 +143,15 @@ void optimize_transfers(timetable const& tt,
         for (auto const& fp :
              tt.locations_
                  .footpaths_out_[q.prf_idx_][stp_from.get_location_idx()]) {
-          if (fp.duration() >= fp_dur_best ||
+          auto const fp_dur =
+              adjusted_transfer_time(q.transfer_time_settings_, fp.duration());
+          if (fp_dur >= fp_dur_best ||
               fp.target() != stp_to.get_location_idx()) {
             continue;
           }
           auto const arr = stp_from.time(event_type::kArr);
           auto const dep = stp_to.time(event_type::kDep);
-          auto const arr_fp = arr + fp.duration();
+          auto const arr_fp = arr + fp_dur;
           if (arr_fp <= dep) {
             leg_from.to_ = stp_from.get_location_idx();
             leg_from.arr_time_ = arr;
@@ -164,7 +168,7 @@ void optimize_transfers(timetable const& tt,
             leg_footpath.arr_time_ = arr_fp;
             leg_footpath.uses_ = fp;
 
-            fp_dur_best = fp.duration();
+            fp_dur_best = fp_dur;
           }
           break;
         }

--- a/src/routing/raptor/reconstruct.cc
+++ b/src/routing/raptor/reconstruct.cc
@@ -81,10 +81,12 @@ std::optional<journey::leg> find_start_footpath(timetable const& tt,
 
       for (auto const& fp : footpaths) {
         if (matches(tt, q.start_match_mode_, o.target(), fp.target()) &&
-            is_better_or_eq(
-                j.start_time_,
-                leg_start_time -
-                    (kFwd ? 1 : -1) * (o.duration() + fp.duration()))) {
+            is_better_or_eq(j.start_time_,
+                            leg_start_time - (kFwd ? 1 : -1) *
+                                                 (o.duration() +
+                                                  adjusted_transfer_time(
+                                                      q.transfer_time_settings_,
+                                                      fp.duration())))) {
           trace_rc_intermodal_fp_start_found;
           return journey::leg{SearchDir,
                               get_special_station(special_station::kStart),
@@ -99,9 +101,11 @@ std::optional<journey::leg> find_start_footpath(timetable const& tt,
     }
   } else {
     for (auto const& fp : footpaths) {
+      auto const fp_duration = adjusted_transfer_time(q.transfer_time_settings_,
+                                                      fp.duration().count());
       if (is_journey_start(tt, q, fp.target()) &&
           fp_target_time != kInvalidDelta<SearchDir> &&
-          start_matches(j_start_time + (kFwd ? 1 : -1) * fp.duration().count(),
+          start_matches(j_start_time + (kFwd ? 1 : -1) * fp_duration,
                         fp_target_time)) {
         trace_rc_fp_start_found;
         return journey::leg{SearchDir,
@@ -109,7 +113,7 @@ std::optional<journey::leg> find_start_footpath(timetable const& tt,
                             leg_start_location,
                             j.start_time_,
                             delta_to_unix(base, fp_target_time),
-                            fp};
+                            footpath{fp.target(), duration_t{fp_duration}}};
       } else {
         trace_rc_fp_start_no_match;
       }
@@ -331,21 +335,27 @@ void reconstruct_journey(timetable const& tt,
   };
 
   auto const check_fp = [&](unsigned const k, location_idx_t const l,
-                            delta_t const curr_time, footpath const fp)
+                            delta_t const curr_time, footpath const fp,
+                            bool const adjust_transfer_time)
       -> std::optional<std::pair<journey::leg, journey::leg>> {
-    auto const fp_start = static_cast<delta_t>(
-        curr_time - (kFwd ? fp.duration() : -fp.duration()).count());
+    auto const fp_duration =
+        adjust_transfer_time ? adjusted_transfer_time(q.transfer_time_settings_,
+                                                      fp.duration().count())
+                             : fp.duration().count();
+    auto const fp_start =
+        static_cast<delta_t>(curr_time - (kFwd ? fp_duration : -fp_duration));
     trace_rc_check_fp;
     auto const transport_leg = get_transport(k, fp.target(), fp_start);
 
     if (transport_leg.has_value()) {
       trace_rc_legs_found;
-      auto const fp_leg = journey::leg{SearchDir,
-                                       fp.target(),
-                                       l,
-                                       delta_to_unix(base, fp_start),
-                                       delta_to_unix(base, curr_time),
-                                       fp};
+      auto const fp_leg =
+          journey::leg{SearchDir,
+                       fp.target(),
+                       l,
+                       delta_to_unix(base, fp_start),
+                       delta_to_unix(base, curr_time),
+                       footpath{fp.target(), duration_t{fp_duration}}};
       return std::pair{fp_leg, *transport_leg};
     } else {
       trace_reconstruct("nothing found\n");
@@ -366,7 +376,7 @@ void reconstruct_journey(timetable const& tt,
             tt, location_match_mode::kIntermodal, dest_offset.target_,
             [&](location_idx_t const eq) {
               auto intermodal_dest =
-                  check_fp(k, l, curr_time, {eq, dest_offset.duration_});
+                  check_fp(k, l, curr_time, {eq, dest_offset.duration_}, false);
               if (intermodal_dest.has_value()) {
                 trace_rc_intermodal_dest_match;
                 intermodal_dest->first.uses_ = offset{
@@ -379,13 +389,15 @@ void reconstruct_journey(timetable const& tt,
               for (auto const& fp :
                    kFwd ? tt.locations_.footpaths_in_[q.prf_idx_][eq]
                         : tt.locations_.footpaths_out_[q.prf_idx_][eq]) {
+                auto const fp_duration = adjusted_transfer_time(
+                    q.transfer_time_settings_, fp.duration());
                 auto fp_intermodal_dest = check_fp(
                     k, l, curr_time,
-                    {fp.target(), dest_offset.duration_ + fp.duration()});
+                    {fp.target(), dest_offset.duration_ + fp_duration}, false);
                 if (fp_intermodal_dest.has_value()) {
                   trace_rc_fp_intermodal_dest_match;
                   fp_intermodal_dest->first.uses_ =
-                      offset{eq, fp.duration(), dest_offset.transport_mode_id_};
+                      offset{eq, fp_duration, dest_offset.transport_mode_id_};
                   ret = std::move(fp_intermodal_dest);
                 } else {
                   trace_rc_fp_intermodal_dest_mismatch;
@@ -404,11 +416,14 @@ void reconstruct_journey(timetable const& tt,
     }
 
     trace_reconstruct("CHECKING TRANSFER AT {}\n", location{tt, l});
-    auto transfer_at_same_stop =
-        check_fp(k, l, curr_time,
-                 footpath{l, (k == j.transfers_ + 1U)
-                                 ? 0_i8_minutes
-                                 : tt.locations_.transfer_time_[l]});
+    auto transfer_at_same_stop = check_fp(
+        k, l, curr_time,
+        footpath{l,
+                 (k == j.transfers_ + 1U)
+                     ? 0_u8_minutes
+                     : adjusted_transfer_time(q.transfer_time_settings_,
+                                              tt.locations_.transfer_time_[l])},
+        false);
     if (transfer_at_same_stop.has_value()) {
       return std::move(*transfer_at_same_stop);
     }
@@ -417,7 +432,7 @@ void reconstruct_journey(timetable const& tt,
     auto const footpaths = kFwd ? tt.locations_.footpaths_in_[q.prf_idx_][l]
                                 : tt.locations_.footpaths_out_[q.prf_idx_][l];
     for (auto const& fp : footpaths) {
-      auto fp_legs = check_fp(k, l, curr_time, fp);
+      auto fp_legs = check_fp(k, l, curr_time, fp, true);
       if (fp_legs.has_value()) {
         return std::move(*fp_legs);
       }

--- a/src/routing/start_times.cc
+++ b/src/routing/start_times.cc
@@ -193,7 +193,8 @@ void get_starts(direction const search_dir,
                 bool const use_start_footpaths,
                 std::vector<start>& starts,
                 bool const add_ontrip,
-                profile_idx_t const prf_idx) {
+                profile_idx_t const prf_idx,
+                transfer_time_settings const& tts) {
   hash_map<location_idx_t, duration_t> shortest_start;
 
   auto const update = [&](location_idx_t const l, duration_t const d) {
@@ -209,7 +210,8 @@ void get_starts(direction const search_dir,
         auto const footpaths = fwd ? tt.locations_.footpaths_out_[prf_idx][l]
                                    : tt.locations_.footpaths_in_[prf_idx][l];
         for (auto const& fp : footpaths) {
-          update(fp.target(), o.duration() + fp.duration());
+          update(fp.target(),
+                 o.duration() + adjusted_transfer_time(tts, fp.duration()));
         }
       }
     });

--- a/test/loader/lb_graph_test.cc
+++ b/test/loader/lb_graph_test.cc
@@ -16,8 +16,8 @@ TEST(routing, lb_graph_distances_check) {
   load_timetable(source_idx_t{0U}, hrd_5_20_26, files_simple(), tt);
   finalize(tt);
 
-  using distance_table_t =
-      std::map<std::pair<std::string, std::string>, duration_t>;
+  using distance_table_t = std::map<std::pair<std::string, std::string>,
+                                    std::pair<duration_t, duration_t>>;
   auto distances = distance_table_t{};
   for (auto i = location_idx_t{0U}; i != tt.locations_.ids_.size(); ++i) {
     if (tt.fwd_search_lb_graph_.at(i).empty()) {
@@ -25,11 +25,13 @@ TEST(routing, lb_graph_distances_check) {
     }
     for (auto const& fp : tt.fwd_search_lb_graph_[i]) {
       distances[{std::string{location{tt, i}.name_},
-                 std::string{location{tt, fp.target()}.name_}}] = fp.duration();
+                 std::string{location{tt, fp.target()}.name_}}] =
+          std::pair{fp.footpath_duration(), fp.trip_duration()};
     }
   }
 
-  EXPECT_EQ(
-      (distance_table_t{{{"A", "B"}, 60_minutes}, {{"B", "A"}, 60_minutes}}),
-      distances);
+  EXPECT_EQ((distance_table_t{
+                {{"A", "B"}, std::pair{lb_entry::kUnreachable, 60_minutes}},
+                {{"B", "A"}, std::pair{lb_entry::kUnreachable, 60_minutes}}}),
+            distances);
 }

--- a/test/raptor_search.cc
+++ b/test/raptor_search.cc
@@ -52,14 +52,16 @@ pareto_set<routing::journey> raptor_search(timetable const& tt,
   }
 }
 
-pareto_set<routing::journey> raptor_search(timetable const& tt,
-                                           rt_timetable const* rtt,
-                                           std::string_view from,
-                                           std::string_view to,
-                                           routing::start_time_t time,
-                                           direction const search_dir,
-                                           routing::clasz_mask_t const mask,
-                                           bool const require_bikes_allowed) {
+pareto_set<routing::journey> raptor_search(
+    timetable const& tt,
+    rt_timetable const* rtt,
+    std::string_view from,
+    std::string_view to,
+    routing::start_time_t time,
+    direction const search_dir,
+    routing::clasz_mask_t const mask,
+    bool const require_bikes_allowed,
+    routing::transfer_time_settings const tts) {
   auto const src = source_idx_t{0};
   auto q = routing::query{
       .start_time_ = time,
@@ -69,20 +71,23 @@ pareto_set<routing::journey> raptor_search(timetable const& tt,
                         0_minutes, 0U}},
       .prf_idx_ = 0,
       .allowed_claszes_ = mask,
-      .require_bike_transport_ = require_bikes_allowed};
+      .require_bike_transport_ = require_bikes_allowed,
+      .transfer_time_settings_ = tts};
   return raptor_search(tt, rtt, std::move(q), search_dir);
 }
 
-pareto_set<routing::journey> raptor_search(timetable const& tt,
-                                           rt_timetable const* rtt,
-                                           std::string_view from,
-                                           std::string_view to,
-                                           std::string_view time,
-                                           direction const search_dir,
-                                           routing::clasz_mask_t mask,
-                                           bool const require_bikes_allowed) {
+pareto_set<routing::journey> raptor_search(
+    timetable const& tt,
+    rt_timetable const* rtt,
+    std::string_view from,
+    std::string_view to,
+    std::string_view time,
+    direction const search_dir,
+    routing::clasz_mask_t mask,
+    bool const require_bikes_allowed,
+    routing::transfer_time_settings const tts) {
   return raptor_search(tt, rtt, from, to, parse_time(time, "%Y-%m-%d %H:%M %Z"),
-                       search_dir, mask, require_bikes_allowed);
+                       search_dir, mask, require_bikes_allowed, tts);
 }
 
 pareto_set<routing::journey> raptor_intermodal_search(

--- a/test/raptor_search.h
+++ b/test/raptor_search.h
@@ -17,7 +17,8 @@ pareto_set<routing::journey> raptor_search(
     std::string_view time,
     direction = direction::kForward,
     routing::clasz_mask_t mask = routing::all_clasz_allowed(),
-    bool require_bikes_allowed = false);
+    bool require_bikes_allowed = false,
+    routing::transfer_time_settings tts = {});
 
 pareto_set<routing::journey> raptor_search(
     timetable const&,
@@ -27,7 +28,8 @@ pareto_set<routing::journey> raptor_search(
     routing::start_time_t,
     direction = direction::kForward,
     routing::clasz_mask_t mask = routing::all_clasz_allowed(),
-    bool require_bikes_allowed = false);
+    bool require_bikes_allowed = false,
+    routing::transfer_time_settings tts = {});
 
 pareto_set<routing::journey> raptor_search(timetable const&,
                                            rt_timetable const*,

--- a/test/routing/bike_transport_test.cc
+++ b/test/routing/bike_transport_test.cc
@@ -240,8 +240,6 @@ leg 2: (C, C) [2019-05-01 08:45] -> (F, F) [2019-05-01 09:05]
 
 )"sv;
 
-}  // namespace
-
 std::string results_to_str(pareto_set<routing::journey> const& results,
                            timetable const& tt,
                            rt_timetable const* rtt = nullptr) {
@@ -265,6 +263,8 @@ pareto_set<routing::journey> search(timetable const& tt,
                        dir == direction::kForward ? to : from, start_time, dir,
                        routing::all_clasz_allowed(), require_bikes_allowed);
 }
+
+}  // namespace
 
 TEST(routing, bike_transport_test_1) {
   auto tt = timetable{};

--- a/test/routing/start_times_test.cc
+++ b/test/routing/start_times_test.cc
@@ -278,7 +278,7 @@ TEST(routing, start_times) {
              interval<unixtime_t>{sys_days{2020_y / March / 30},
                                   sys_days{2020_y / March / 31}},
              {{A, 15_minutes, 0}, {B, 30_minutes, 0}},
-             location_match_mode::kExact, false, starts, true, 0);
+             location_match_mode::kExact, false, starts, true, 0, {});
   std::sort(begin(starts), end(starts),
             [](auto&& a, auto&& b) { return a > b; });
   starts.erase(std::unique(begin(starts), end(starts)), end(starts));

--- a/test/routing/transfer_time_settings_test.cc
+++ b/test/routing/transfer_time_settings_test.cc
@@ -27,7 +27,7 @@ namespace {
 // Trips:
 // T1: A 10:00 -> B 10:10
 // T2: B 10:13 -> C 10:22 (departure 3 min after T1 arrival)
-// T3: B 10:20 -> C 10:30 (departure 10 min after T2 arrival)
+// T3: B 10:20 -> C 10:30 (departure 10 min after T1 arrival)
 // Transfer times for all stations: 2 min (default)
 constexpr auto const test_files = R"(
 # agency.txt

--- a/test/routing/transfer_time_settings_test.cc
+++ b/test/routing/transfer_time_settings_test.cc
@@ -1,0 +1,219 @@
+
+#include "gtest/gtest.h"
+
+#include "utl/erase_if.h"
+
+#include "nigiri/loader/gtfs/agency.h"
+#include "nigiri/loader/gtfs/calendar.h"
+#include "nigiri/loader/gtfs/calendar_date.h"
+#include "nigiri/loader/gtfs/load_timetable.h"
+#include "nigiri/loader/gtfs/local_to_utc.h"
+#include "nigiri/loader/gtfs/noon_offsets.h"
+#include "nigiri/loader/init_finish.h"
+
+#include "nigiri/rt/rt_timetable.h"
+#include "nigiri/timetable.h"
+
+#include "../raptor_search.h"
+
+using namespace nigiri;
+using namespace date;
+using namespace std::chrono_literals;
+using namespace std::string_view_literals;
+using nigiri::test::raptor_search;
+
+namespace {
+
+// Trips:
+// T1: A 10:00 -> B 10:10
+// T2: B 10:13 -> C 10:22 (departure 3 min after T1 arrival)
+// T3: B 10:20 -> C 10:30 (departure 10 min after T2 arrival)
+// Transfer times for all stations: 2 min (default)
+constexpr auto const test_files = R"(
+# agency.txt
+agency_id,agency_name,agency_url,agency_timezone
+DB,Deutsche Bahn,https://deutschebahn.com,Europe/Berlin
+
+# stops.txt
+stop_id,stop_name,stop_desc,stop_lat,stop_lon,stop_url,location_type,parent_station
+A,A,,0.0,1.0,,
+B,B,,2.0,3.0,,
+C,C,,4.0,5.0,,
+
+# routes.txt
+route_id,agency_id,route_short_name,route_long_name,route_desc,route_type
+R1,DB,1,,,3
+R2,DB,2,,,3
+
+# trips.txt
+route_id,service_id,trip_id,trip_headsign,block_id
+R1,S1,T1,,
+R2,S1,T2,,
+R2,S1,T3,,
+
+# stop_times.txt
+trip_id,arrival_time,departure_time,stop_id,stop_sequence
+T1,10:00:00,10:00:00,A,0
+T1,10:10:00,10:10:00,B,1
+T2,10:13:00,10:13:00,B,0
+T2,10:22:00,10:22:00,C,1
+T3,10:20:00,10:20:00,B,0
+T3,10:30:00,10:30:00,C,1
+
+# calendar_dates.txt
+service_id,date,exception_type
+S1,20190501,1
+)"sv;
+
+constexpr auto const expected_A_C_default =
+    R"(
+[2019-05-01 08:00, 2019-05-01 08:22]
+TRANSFERS: 1
+     FROM: (A, A) [2019-05-01 08:00]
+       TO: (C, C) [2019-05-01 08:22]
+leg 0: (A, A) [2019-05-01 08:00] -> (B, B) [2019-05-01 08:10]
+   0: A       A...............................................                               d: 01.05 08:00 [01.05 10:00]  [{name=Bus 1, day=2019-05-01, id=T1, src=0}]
+   1: B       B............................................... a: 01.05 08:10 [01.05 10:10]
+leg 1: (B, B) [2019-05-01 08:10] -> (B, B) [2019-05-01 08:12]
+  FOOTPATH (duration=2)
+leg 2: (B, B) [2019-05-01 08:13] -> (C, C) [2019-05-01 08:22]
+   0: B       B...............................................                               d: 01.05 08:13 [01.05 10:13]  [{name=Bus 2, day=2019-05-01, id=T2, src=0}]
+   1: C       C............................................... a: 01.05 08:22 [01.05 10:22]
+
+
+)"sv;
+
+constexpr auto const expected_A_C_min10 =
+    R"(
+[2019-05-01 08:00, 2019-05-01 08:30]
+TRANSFERS: 1
+     FROM: (A, A) [2019-05-01 08:00]
+       TO: (C, C) [2019-05-01 08:30]
+leg 0: (A, A) [2019-05-01 08:00] -> (B, B) [2019-05-01 08:10]
+   0: A       A...............................................                               d: 01.05 08:00 [01.05 10:00]  [{name=Bus 1, day=2019-05-01, id=T1, src=0}]
+   1: B       B............................................... a: 01.05 08:10 [01.05 10:10]
+leg 1: (B, B) [2019-05-01 08:10] -> (B, B) [2019-05-01 08:20]
+  FOOTPATH (duration=10)
+leg 2: (B, B) [2019-05-01 08:20] -> (C, C) [2019-05-01 08:30]
+   0: B       B...............................................                               d: 01.05 08:20 [01.05 10:20]  [{name=Bus 2, day=2019-05-01, id=T3, src=0}]
+   1: C       C............................................... a: 01.05 08:30 [01.05 10:30]
+
+
+)"sv;
+
+constexpr auto const expected_A_C_f15 =
+    R"(
+[2019-05-01 08:00, 2019-05-01 08:22]
+TRANSFERS: 1
+     FROM: (A, A) [2019-05-01 08:00]
+       TO: (C, C) [2019-05-01 08:22]
+leg 0: (A, A) [2019-05-01 08:00] -> (B, B) [2019-05-01 08:10]
+   0: A       A...............................................                               d: 01.05 08:00 [01.05 10:00]  [{name=Bus 1, day=2019-05-01, id=T1, src=0}]
+   1: B       B............................................... a: 01.05 08:10 [01.05 10:10]
+leg 1: (B, B) [2019-05-01 08:10] -> (B, B) [2019-05-01 08:13]
+  FOOTPATH (duration=3)
+leg 2: (B, B) [2019-05-01 08:13] -> (C, C) [2019-05-01 08:22]
+   0: B       B...............................................                               d: 01.05 08:13 [01.05 10:13]  [{name=Bus 2, day=2019-05-01, id=T2, src=0}]
+   1: C       C............................................... a: 01.05 08:22 [01.05 10:22]
+
+
+)"sv;
+
+constexpr auto const expected_A_C_f20 =
+    R"(
+[2019-05-01 08:00, 2019-05-01 08:30]
+TRANSFERS: 1
+     FROM: (A, A) [2019-05-01 08:00]
+       TO: (C, C) [2019-05-01 08:30]
+leg 0: (A, A) [2019-05-01 08:00] -> (B, B) [2019-05-01 08:10]
+   0: A       A...............................................                               d: 01.05 08:00 [01.05 10:00]  [{name=Bus 1, day=2019-05-01, id=T1, src=0}]
+   1: B       B............................................... a: 01.05 08:10 [01.05 10:10]
+leg 1: (B, B) [2019-05-01 08:10] -> (B, B) [2019-05-01 08:14]
+  FOOTPATH (duration=4)
+leg 2: (B, B) [2019-05-01 08:20] -> (C, C) [2019-05-01 08:30]
+   0: B       B...............................................                               d: 01.05 08:20 [01.05 10:20]  [{name=Bus 2, day=2019-05-01, id=T3, src=0}]
+   1: C       C............................................... a: 01.05 08:30 [01.05 10:30]
+
+
+)"sv;
+
+std::string results_to_str(pareto_set<routing::journey> const& results,
+                           timetable const& tt,
+                           rt_timetable const* rtt = nullptr) {
+  std::stringstream ss;
+  ss << "\n";
+  for (auto const& j : results) {
+    j.print(ss, tt, rtt);
+    ss << "\n\n";
+  }
+  return ss.str();
+}
+
+pareto_set<routing::journey> search(timetable const& tt,
+                                    rt_timetable const* rtt,
+                                    std::string_view const from,
+                                    std::string_view const to,
+                                    routing::start_time_t const start_time,
+                                    direction const dir,
+                                    routing::transfer_time_settings const tts) {
+  return raptor_search(tt, rtt, dir == direction::kForward ? from : to,
+                       dir == direction::kForward ? to : from, start_time, dir,
+                       routing::all_clasz_allowed(), false, tts);
+}
+
+}  // namespace
+
+TEST(routing, transfer_time_settings_test) {
+  auto tt = timetable{};
+
+  tt.date_range_ = {date::sys_days{2019_y / May / 1},
+                    date::sys_days{2019_y / May / 2}};
+  loader::register_special_stations(tt);
+  loader::gtfs::load_timetable({}, source_idx_t{0},
+                               loader::mem_dir::read(test_files), tt);
+  loader::finalize(tt);
+
+  for (auto const dir : {direction::kForward, direction::kBackward}) {
+
+    {  // A -> C, default transfer time (= 2 min)
+      auto const results =
+          search(tt, nullptr, "A", "C", tt.date_range_, dir, {});
+      EXPECT_EQ(expected_A_C_default, results_to_str(results, tt));
+    }
+
+    {  // A -> C, min 10 min transfer time (= 10 min)
+      auto const results =
+          search(tt, nullptr, "A", "C", tt.date_range_, dir,
+                 {.default_ = false, .min_transfer_time_ = duration_t{10}});
+      EXPECT_EQ(expected_A_C_min10, results_to_str(results, tt));
+    }
+
+    {  // A -> C, 1.5x transfer time (= 3 min)
+      auto const results = search(tt, nullptr, "A", "C", tt.date_range_, dir,
+                                  {.default_ = false, .factor_ = 1.5F});
+      EXPECT_EQ(expected_A_C_f15, results_to_str(results, tt));
+    }
+
+    {  // A -> C, 2.0x transfer time (= 4 min)
+      auto const results = search(tt, nullptr, "A", "C", tt.date_range_, dir,
+                                  {.default_ = false, .factor_ = 2.0F});
+      EXPECT_EQ(expected_A_C_f20, results_to_str(results, tt));
+    }
+
+    {  // A -> C, min 10 min transfer time, 2.0x transfer time (= 10 min)
+      auto const results = search(tt, nullptr, "A", "C", tt.date_range_, dir,
+                                  {.default_ = false,
+                                   .min_transfer_time_ = duration_t{10},
+                                   .factor_ = 2.0F});
+      EXPECT_EQ(expected_A_C_min10, results_to_str(results, tt));
+    }
+
+    {  // A -> C, min 3 min transfer time, 2.0x transfer time (= 4 min)
+      auto const results = search(tt, nullptr, "A", "C", tt.date_range_, dir,
+                                  {.default_ = false,
+                                   .min_transfer_time_ = duration_t{3},
+                                   .factor_ = 2.0F});
+      EXPECT_EQ(expected_A_C_f20, results_to_str(results, tt));
+    }
+  }
+}


### PR DESCRIPTION
Same as #113, but with adjusted lower bounds.

Routing performance seems to be very similar:

Benchmark results from `nigiri-benchmark` with options `--start_mode station --dest_mode station -m 0 -e false -l false -n 5000` + transfer time settings, current DELFI GTFS timetable

## Default transfer times

#113 (default LB):
```
--- total_time --- (n = 5000)
  10%: (t_total: 00000.385s, t_exec: 00000.360s, intvl_ext: 00, intvl_size: 00001h, #jrny:  2)
  20%: (t_total:     0.613s, t_exec:     0.559s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
  30%: (t_total:     0.787s, t_exec:     0.751s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
  40%: (t_total:     0.943s, t_exec:     0.902s, intvl_ext:  0, intvl_size:     1h, #jrny:  3)
  50%: (t_total:     1.097s, t_exec:     1.064s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
  60%: (t_total:     1.273s, t_exec:     1.240s, intvl_ext:  0, intvl_size:     1h, #jrny:  1)
  70%: (t_total:     1.461s, t_exec:     1.436s, intvl_ext:  0, intvl_size:     1h, #jrny:  3)
  80%: (t_total:     1.705s, t_exec:     1.674s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
  90%: (t_total:     2.053s, t_exec:     2.007s, intvl_ext:  0, intvl_size:     1h, #jrny:  3)
  99%: (t_total:     2.961s, t_exec:     2.923s, intvl_ext:  0, intvl_size:     1h, #jrny:  1)
99.9%: (t_total:     3.847s, t_exec:     3.807s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
  max: (t_total:     4.045s, t_exec:     4.014s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
----------------------------------
```

#114 (adjusted LB):
```
--- total_time --- (n = 5000)
  10%: (t_total: 00000.402s, t_exec: 00000.365s, intvl_ext: 00, intvl_size: 00001h, #jrny:  3)
  20%: (t_total:     0.616s, t_exec:     0.581s, intvl_ext:  0, intvl_size:     1h, #jrny:  1)
  30%: (t_total:     0.791s, t_exec:     0.757s, intvl_ext:  0, intvl_size:     1h, #jrny:  1)
  40%: (t_total:     0.949s, t_exec:     0.909s, intvl_ext:  0, intvl_size:     1h, #jrny:  1)
  50%: (t_total:     1.102s, t_exec:     1.062s, intvl_ext:  0, intvl_size:     1h, #jrny:  3)
  60%: (t_total:     1.266s, t_exec:     1.221s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
  70%: (t_total:     1.456s, t_exec:     1.402s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
  80%: (t_total:     1.656s, t_exec:     1.602s, intvl_ext:  0, intvl_size:     1h, #jrny:  1)
  90%: (t_total:     1.996s, t_exec:     1.951s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
  99%: (t_total:     2.891s, t_exec:     2.839s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
99.9%: (t_total:     4.019s, t_exec:     3.967s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
  max: (t_total:     5.109s, t_exec:     5.065s, intvl_ext:  0, intvl_size:     1h, #jrny:  1)
----------------------------------
```

## Min transfer time 10 minutes

#113 (default LB):
```
--- total_time --- (n = 5000)
  10%: (t_total: 00000.362s, t_exec: 00000.331s, intvl_ext: 00, intvl_size: 00001h, #jrny:  1)
  20%: (t_total:     0.576s, t_exec:     0.515s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
  30%: (t_total:     0.752s, t_exec:     0.727s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
  40%: (t_total:     0.891s, t_exec:     0.851s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
  50%: (t_total:     1.030s, t_exec:     0.977s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
  60%: (t_total:     1.166s, t_exec:     1.132s, intvl_ext:  0, intvl_size:     1h, #jrny:  3)
  70%: (t_total:     1.329s, t_exec:     1.304s, intvl_ext:  0, intvl_size:     1h, #jrny:  3)
  80%: (t_total:     1.530s, t_exec:     1.505s, intvl_ext:  0, intvl_size:     1h, #jrny:  3)
  90%: (t_total:     1.838s, t_exec:     1.785s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
  99%: (t_total:     2.658s, t_exec:     2.628s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
99.9%: (t_total:     3.242s, t_exec:     3.207s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
  max: (t_total:     3.947s, t_exec:     3.913s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
----------------------------------
```

#114 (adjusted LB):
```
--- total_time --- (n = 5000)
  10%: (t_total: 00000.362s, t_exec: 00000.302s, intvl_ext: 00, intvl_size: 00001h, #jrny:  2)
  20%: (t_total:     0.571s, t_exec:     0.525s, intvl_ext:  0, intvl_size:     1h, #jrny:  3)
  30%: (t_total:     0.737s, t_exec:     0.694s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
  40%: (t_total:     0.878s, t_exec:     0.838s, intvl_ext:  0, intvl_size:     1h, #jrny:  4)
  50%: (t_total:     1.007s, t_exec:     0.946s, intvl_ext:  0, intvl_size:     1h, #jrny:  1)
  60%: (t_total:     1.155s, t_exec:     1.116s, intvl_ext:  0, intvl_size:     1h, #jrny:  3)
  70%: (t_total:     1.334s, t_exec:     1.273s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
  80%: (t_total:     1.551s, t_exec:     1.500s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
  90%: (t_total:     1.840s, t_exec:     1.801s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
  99%: (t_total:     2.608s, t_exec:     2.514s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
99.9%: (t_total:     3.885s, t_exec:     3.833s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
  max: (t_total:     3.947s, t_exec:     3.885s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
----------------------------------
```

## Transfer time factor 2.0x

#113 (default LB):
```
--- total_time --- (n = 5000)
  10%: (t_total: 00000.368s, t_exec: 00000.342s, intvl_ext: 00, intvl_size: 00001h, #jrny:  1)
  20%: (t_total:     0.596s, t_exec:     0.564s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
  30%: (t_total:     0.775s, t_exec:     0.741s, intvl_ext:  0, intvl_size:     1h, #jrny:  1)
  40%: (t_total:     0.931s, t_exec:     0.853s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
  50%: (t_total:     1.079s, t_exec:     1.047s, intvl_ext:  0, intvl_size:     1h, #jrny:  1)
  60%: (t_total:     1.240s, t_exec:     1.198s, intvl_ext:  0, intvl_size:     1h, #jrny:  1)
  70%: (t_total:     1.427s, t_exec:     1.379s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
  80%: (t_total:     1.649s, t_exec:     1.617s, intvl_ext:  0, intvl_size:     1h, #jrny:  1)
  90%: (t_total:     1.981s, t_exec:     1.940s, intvl_ext:  0, intvl_size:     1h, #jrny:  3)
  99%: (t_total:     2.901s, t_exec:     2.872s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
99.9%: (t_total:     3.885s, t_exec:     3.860s, intvl_ext:  0, intvl_size:     1h, #jrny:  3)
  max: (t_total:     4.838s, t_exec:     4.800s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
----------------------------------
```

#114 (adjusted LB):
```
--- total_time --- (n = 5000)
  10%: (t_total: 00000.405s, t_exec: 00000.369s, intvl_ext: 00, intvl_size: 00001h, #jrny:  1)
  20%: (t_total:     0.629s, t_exec:     0.573s, intvl_ext:  0, intvl_size:     1h, #jrny:  5)
  30%: (t_total:     0.793s, t_exec:     0.724s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
  40%: (t_total:     0.938s, t_exec:     0.888s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
  50%: (t_total:     1.088s, t_exec:     1.044s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
  60%: (t_total:     1.249s, t_exec:     1.208s, intvl_ext:  0, intvl_size:     1h, #jrny:  1)
  70%: (t_total:     1.425s, t_exec:     1.377s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
  80%: (t_total:     1.660s, t_exec:     1.609s, intvl_ext:  0, intvl_size:     1h, #jrny:  2)
  90%: (t_total:     2.014s, t_exec:     1.967s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
  99%: (t_total:     2.878s, t_exec:     2.836s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
99.9%: (t_total:     4.021s, t_exec:     3.980s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
  max: (t_total:     4.300s, t_exec:     4.269s, intvl_ext:  0, intvl_size:     1h, #jrny:  0)
----------------------------------
```
