### PR TITLE
Start footpaths

### DIFF
--- a/include/nigiri/query_generator/generator_settings.h
+++ b/include/nigiri/query_generator/generator_settings.h
@@ -16,7 +16,7 @@ struct generator_settings {
       routing::location_match_mode::kIntermodal};
   transport_mode start_mode_{kWalk};
   transport_mode dest_mode_{kWalk};
-  bool use_start_footpaths_{true};
+  bool use_start_footpaths_{false};
   std::uint8_t max_transfers_{routing::kMaxTransfers};
   unsigned min_connection_count_{0U};
   bool extend_interval_earlier_{false};

--- a/include/nigiri/routing/query.h
+++ b/include/nigiri/routing/query.h
@@ -45,7 +45,7 @@ struct query {
       nigiri::routing::location_match_mode::kExact};
   location_match_mode dest_match_mode_{
       nigiri::routing::location_match_mode::kExact};
-  bool use_start_footpaths_{true};
+  bool use_start_footpaths_{false};
   std::vector<offset> start_;
   std::vector<offset> destination_;
   std::uint8_t max_transfers_{kMaxTransfers};

--- a/include/nigiri/types.h
+++ b/include/nigiri/types.h
@@ -288,6 +288,23 @@ enum class location_type : std::uint8_t {
 };
 
 enum class event_type { kArr, kDep };
+
+/*
+                  |                       Search direction                     |
+                  |  Forward                      |  Backward                  |
+------------------|-------------------------------|----------------------------|
+Algo perspective  |                      User perspective                     |
+                  |                               |                            |
+    Start         |  Initial departure            |  Final arrival             |
+                  |                               |                            |
+    Destination   |  Final arrival                |  Initial departure         |
+                  |                               |                            |
+    Start match   |  Offset mode to               |  Offset mode from          |
+       mode       |  initial departure            |  final arrival             |
+                  |                               |                            |
+    Dest match    |  Offset mode from             |  Offset mode to            |
+       mode       |  final arrival                |  initial departure         |
+ */
 enum class direction { kForward, kBackward };
 
 using transport_mode_id_t = std::int32_t;

--- a/include/nigiri/types.h
+++ b/include/nigiri/types.h
@@ -293,7 +293,7 @@ enum class event_type { kArr, kDep };
                   |                       Search direction                     |
                   |  Forward                      |  Backward                  |
 ------------------|-------------------------------|----------------------------|
- Algo perspective |                      User perspective                     |
+ Algo perspective |                      User perspective                      |
                   |                               |                            |
     Start         |  Initial departure            |  Final arrival             |
                   |                               |                            |

--- a/include/nigiri/types.h
+++ b/include/nigiri/types.h
@@ -293,7 +293,7 @@ enum class event_type { kArr, kDep };
                   |                       Search direction                     |
                   |  Forward                      |  Backward                  |
 ------------------|-------------------------------|----------------------------|
-Algo perspective  |                      User perspective                     |
+ Algo perspective |                      User perspective                     |
                   |                               |                            |
     Start         |  Initial departure            |  Final arrival             |
                   |                               |                            |

--- a/include/nigiri/types.h
+++ b/include/nigiri/types.h
@@ -289,23 +289,10 @@ enum class location_type : std::uint8_t {
 
 enum class event_type { kArr, kDep };
 
-/*
-                  |                       Search direction                     |
-                  |  Forward                      |  Backward                  |
-------------------|-------------------------------|----------------------------|
- Algo perspective |                      User perspective                      |
-                  |                               |                            |
-    Start         |  Initial departure            |  Final arrival             |
-                  |                               |                            |
-    Destination   |  Final arrival                |  Initial departure         |
-                  |                               |                            |
-    Start match   |  Offset mode to               |  Offset mode from          |
-       mode       |  initial departure            |  final arrival             |
-                  |                               |                            |
-    Dest match    |  Offset mode from             |  Offset mode to            |
-       mode       |  final arrival                |  initial departure         |
- */
-enum class direction { kForward, kBackward };
+enum class direction {
+  kForward,
+  kBackward  // start = final arrival, destination = journey departure
+};
 
 using transport_mode_id_t = std::int32_t;
 


### PR DESCRIPTION
- changes the default value for `use_start_footpaths` to `false`
- adds a comment that explains the relation between search direction and user perspective