### PR TITLE
Allow optional creation mode

### DIFF
--- a/include/nigiri/shape.h
+++ b/include/nigiri/shape.h
@@ -9,7 +9,7 @@
 
 namespace nigiri {
 struct timetable;
-}  // namespace nigiri
+}
 
 namespace nigiri {
 

--- a/include/nigiri/shape.h
+++ b/include/nigiri/shape.h
@@ -9,11 +9,13 @@
 
 namespace nigiri {
 struct timetable;
-}
+}  // namespace nigiri
 
 namespace nigiri {
 
-shapes_storage_t create_shapes_storage(std::filesystem::path const&);
+shapes_storage_t create_shapes_storage(
+    std::filesystem::path const&,
+    cista::mmap::protection = cista::mmap::protection::WRITE);
 
 std::span<geo::latlng const> get_shape(timetable const&,
                                        shapes_storage_t const&,

--- a/src/shape.cc
+++ b/src/shape.cc
@@ -13,7 +13,7 @@ shapes_storage_t create_shapes_storage(std::filesystem::path const& path,
           fmt::format("{}_data.bin", path.generic_string()).c_str(), mode}},
       cista::basic_mmap_vec<cista::base_t<shape_idx_t>, std::uint64_t>{
           cista::mmap{fmt::format("{}_idx.bin", path.generic_string()).c_str(),
-                      kMode}}};
+                      mode}}};
 }
 
 std::span<geo::latlng const> get_shape(timetable const& tt,

--- a/src/shape.cc
+++ b/src/shape.cc
@@ -6,8 +6,8 @@
 
 namespace nigiri {
 
-shapes_storage_t create_shapes_storage(std::filesystem::path const& path) {
-  constexpr auto const kMode = cista::mmap::protection::WRITE;
+shapes_storage_t create_shapes_storage(std::filesystem::path const& path,
+                                       cista::mmap::protection const kMode) {
   return {
       cista::basic_mmap_vec<geo::latlng, std::uint64_t>{cista::mmap{
           fmt::format("{}_data.bin", path.generic_string()).c_str(), kMode}},

--- a/src/shape.cc
+++ b/src/shape.cc
@@ -7,10 +7,10 @@
 namespace nigiri {
 
 shapes_storage_t create_shapes_storage(std::filesystem::path const& path,
-                                       cista::mmap::protection const kMode) {
+                                       cista::mmap::protection const mode) {
   return {
       cista::basic_mmap_vec<geo::latlng, std::uint64_t>{cista::mmap{
-          fmt::format("{}_data.bin", path.generic_string()).c_str(), kMode}},
+          fmt::format("{}_data.bin", path.generic_string()).c_str(), mode}},
       cista::basic_mmap_vec<cista::base_t<shape_idx_t>, std::uint64_t>{
           cista::mmap{fmt::format("{}_idx.bin", path.generic_string()).c_str(),
                       kMode}}};


### PR DESCRIPTION
Making the creation mode optional allows clients to load stored data without duplicating this function. This is especially useful if import and usage can run independently.
For instance, it could be applied to motis-project/motis#537 immediately to remove duplicated code.