### PR TITLE
fix split for negative whole day deltas

### DIFF
--- a/include/nigiri/common/delta_t.h
+++ b/include/nigiri/common/delta_t.h
@@ -51,16 +51,8 @@ inline std::pair<day_idx_t, minutes_after_midnight_t> split_day_mam(
     day_idx_t const base, delta_t const x) {
   assert(x != std::numeric_limits<delta_t>::min());
   assert(x != std::numeric_limits<delta_t>::max());
-  if (x < 0) {
-    auto const o = (x % 1440) == 0 ? 0 : 1;
-    auto const t = -x / 1440 + o;
-    auto const min = x + (t * 1440);
-    return {static_cast<day_idx_t>(static_cast<int>(to_idx(base)) - t),
-            minutes_after_midnight_t{min}};
-  } else {
-    return {static_cast<day_idx_t>(static_cast<int>(to_idx(base)) + x / 1440),
-            minutes_after_midnight_t{x % 1440}};
-  }
+  auto const minutes = base.v_ * 1440 + x;
+  return {day_idx_t{minutes / 1440}, minutes_after_midnight_t{minutes % 1440}};
 }
 
 }  // namespace nigiri

--- a/include/nigiri/common/delta_t.h
+++ b/include/nigiri/common/delta_t.h
@@ -52,7 +52,8 @@ inline std::pair<day_idx_t, minutes_after_midnight_t> split_day_mam(
   assert(x != std::numeric_limits<delta_t>::min());
   assert(x != std::numeric_limits<delta_t>::max());
   if (x < 0) {
-    auto const t = -x / 1440 + 1;
+    auto const o = (x % 1440) == 0 ? 0 : 1;
+    auto const t = -x / 1440 + o;
     auto const min = x + (t * 1440);
     return {static_cast<day_idx_t>(static_cast<int>(to_idx(base)) - t),
             minutes_after_midnight_t{min}};

--- a/test/delta_t_test.cc
+++ b/test/delta_t_test.cc
@@ -1,0 +1,33 @@
+#include "gtest/gtest.h"
+
+#include "nigiri/common/delta_t.h"
+
+using namespace nigiri;
+
+TEST(DeltaT, NegDeltaValue) {
+  {
+    auto [day, mam] = split_day_mam(day_idx_t{10}, delta_t{0});
+    EXPECT_EQ(day, day_idx_t{10});
+    EXPECT_EQ(mam.count(), 0);
+  }
+  {
+    auto [day, mam] = split_day_mam(day_idx_t{10}, delta_t{1441});
+    EXPECT_EQ(day, day_idx_t{11});
+    EXPECT_EQ(mam.count(), 1);
+  }
+  {
+    auto [day, mam] = split_day_mam(day_idx_t{10}, delta_t{1440});
+    EXPECT_EQ(day, day_idx_t{11});
+    EXPECT_EQ(mam.count(), 0);
+  }
+  {
+    auto [day, mam] = split_day_mam(day_idx_t{10}, delta_t{-1441});
+    EXPECT_EQ(day, day_idx_t{8});
+    EXPECT_EQ(mam.count(), 1439);
+  }
+  {
+    auto [day, mam] = split_day_mam(day_idx_t{10}, delta_t{-1440});
+    EXPECT_EQ(day, day_idx_t{9});
+    EXPECT_EQ(mam.count(), 0);
+  }
+}


### PR DESCRIPTION
old version (not what you would expect):
    auto [day, mam] = split_day_mam(day_idx_t{10}, delta_t{-1440});
    EXPECT_EQ(day, day_idx_t{8});
    EXPECT_EQ(mam.count(), 1440);

now:
    auto [day, mam] = split_day_mam(day_idx_t{10}, delta_t{-1440});
    EXPECT_EQ(day, day_idx_t{9});
    EXPECT_EQ(mam.count(), 0);