### PR TITLE
Extend ABI to expose journeys, footpaths, cancellations

### DIFF
--- a/include/nigiri/abi.h
+++ b/include/nigiri/abi.h
@@ -110,6 +110,7 @@ void nigiri_destroy_transport(const nigiri_transport_t* transport);
 bool nigiri_is_transport_active(const nigiri_timetable_t* t,
                                 const uint32_t transport_idx,
                                 uint16_t day_idx);
+uint32_t nigiri_get_route_count(const nigiri_timetable_t* t);
 nigiri_route_t* nigiri_get_route(const nigiri_timetable_t* t, uint32_t idx);
 void nigiri_destroy_route(const nigiri_route_t* route);
 uint32_t nigiri_get_location_count(const nigiri_timetable_t* t);

--- a/include/nigiri/abi.h
+++ b/include/nigiri/abi.h
@@ -60,9 +60,10 @@ struct nigiri_event_change {
   uint16_t day_idx;
   uint16_t stop_idx;
   bool is_departure;
-  uint32_t location_idx;  // 0 if unset
-  int16_t in_out_allowed;  // -1 if unset
-  int16_t delay;
+  bool stop_change;
+  uint32_t stop_location_idx;  // ignore if UINT_MAX or stop_change == false
+  bool stop_in_out_allowed;  // ignore if stop_change == false
+  int16_t delay;  // ignore if stop_change == true
 };
 typedef struct nigiri_event_change nigiri_event_change_t;
 

--- a/include/nigiri/rt/rt_timetable.h
+++ b/include/nigiri/rt/rt_timetable.h
@@ -13,8 +13,9 @@ namespace nigiri {
 using change_callback_t = std::function<void(transport const transport,
                                              stop_idx_t const stop_idx,
                                              event_type const ev_type,
-                                             duration_t const delay,
-                                             bool const cancelled)>;
+                                             location_idx_t const location_idx,
+                                             int16_t const in_out_allowed,
+                                             duration_t const delay)>;
 
 // General note:
 // - The real-time timetable does not use bitfields. It requires an initial copy
@@ -63,13 +64,15 @@ struct rt_timetable {
 
   void reset_change_callback() { change_callback_ = nullptr; }
 
-  void dispatch_event_change(transport const t,
+  void dispatch_event_change(transport const transport,
                              stop_idx_t const stop_idx,
                              event_type const ev_type,
-                             duration_t const delay,
-                             bool const cancelled) {
+                             location_idx_t const location_idx,
+                             int16_t const in_out_allowed,
+                             duration_t const delay) {
     if (change_callback_) {
-      change_callback_(t, stop_idx, ev_type, delay, cancelled);
+      change_callback_(transport, stop_idx, ev_type, location_idx,
+                       in_out_allowed, delay);
     }
   }
 

--- a/include/nigiri/rt/rt_timetable.h
+++ b/include/nigiri/rt/rt_timetable.h
@@ -4,18 +4,20 @@
 
 #include "nigiri/common/delta_t.h"
 #include "nigiri/common/interval.h"
+#include "nigiri/rt/run.h"
 #include "nigiri/stop.h"
 #include "nigiri/timetable.h"
 #include "nigiri/types.h"
 
 namespace nigiri {
 
-using change_callback_t = std::function<void(transport const transport,
-                                             stop_idx_t const stop_idx,
-                                             event_type const ev_type,
-                                             location_idx_t const location_idx,
-                                             int16_t const in_out_allowed,
-                                             duration_t const delay)>;
+using change_callback_t =
+    std::function<void(transport const transport,
+                       stop_idx_t const stop_idx,
+                       event_type const ev_type,
+                       std::optional<location_idx_t> const location_idx,
+                       std::optional<bool> const in_out_allowed,
+                       std::optional<duration_t> const delay)>;
 
 // General note:
 // - The real-time timetable does not use bitfields. It requires an initial copy
@@ -64,16 +66,34 @@ struct rt_timetable {
 
   void reset_change_callback() { change_callback_ = nullptr; }
 
-  void dispatch_event_change(transport const transport,
-                             stop_idx_t const stop_idx,
-                             event_type const ev_type,
-                             location_idx_t const location_idx,
-                             int16_t const in_out_allowed,
-                             duration_t const delay) {
-    if (change_callback_) {
-      change_callback_(transport, stop_idx, ev_type, location_idx,
-                       in_out_allowed, delay);
+  void dispatch_event(rt::run const& r,
+                      stop_idx_t const stop_idx,
+                      event_type const ev_type,
+                      std::optional<location_idx_t> const location_idx,
+                      std::optional<bool> const in_out_allowed,
+                      std::optional<duration_t> const delay) {
+    if (change_callback_ &&
+        ((ev_type == event_type::kArr && stop_idx != r.stop_range_.from_) ||
+         (ev_type == event_type::kDep && stop_idx != r.stop_range_.to_ - 1))) {
+      change_callback_(r.t_, stop_idx, ev_type, location_idx, in_out_allowed,
+                       delay);
     }
+  }
+
+  void dispatch_delay(rt::run const& r,
+                      stop_idx_t const stop_idx,
+                      event_type const ev_type,
+                      duration_t const delay) {
+    dispatch_event(r, stop_idx, ev_type, std::nullopt, std::nullopt, delay);
+  }
+
+  void dispatch_stop_change(rt::run const& r,
+                            stop_idx_t const stop_idx,
+                            event_type const ev_type,
+                            std::optional<location_idx_t> const location_idx,
+                            std::optional<bool> const in_out_allowed) {
+    dispatch_event(r, stop_idx, ev_type, location_idx, in_out_allowed,
+                   std::nullopt);
   }
 
   unixtime_t unix_event_time(rt_transport_idx_t const rt_t,

--- a/src/abi.cc
+++ b/src/abi.cc
@@ -173,15 +173,15 @@ uint32_t nigiri_get_route_count(const nigiri_timetable_t* t) {
 nigiri_route_t* nigiri_get_route(const nigiri_timetable_t* t, uint32_t idx) {
   auto const ridx = nigiri::route_idx_t{idx};
   auto stops = t->tt->route_location_seq_[ridx];
+  auto route = new nigiri_route_t;
   auto const n_stops = stops.size();
-  auto route_stops = new nigiri_route_stop_t[n_stops];
   if (n_stops > 0) {
+    auto route_stops = new nigiri_route_stop_t[n_stops];
     std::memcpy(route_stops, &stops.front(),
                 sizeof(nigiri_route_stop_t) * n_stops);
+    route->stops = route_stops;
   }
-  auto route = new nigiri_route_t;
 
-  route->stops = route_stops;
   route->n_stops = static_cast<uint16_t>(n_stops);
   route->clasz =
       static_cast<uint16_t>(t->tt->route_section_clasz_[ridx].front());
@@ -213,8 +213,8 @@ nigiri_location_t* nigiri_get_location_with_footpaths(
                        ? t->tt->locations_.footpaths_in_[0][lidx]
                        : t->tt->locations_.footpaths_out_[0][lidx];
   auto const n_footpaths = footpaths.size();
-  location->footpaths = new nigiri_footpath_t[n_footpaths];
   if (n_footpaths > 0) {
+    location->footpaths = new nigiri_footpath_t[n_footpaths];
     std::memcpy(location->footpaths, &footpaths.front(),
                 sizeof(nigiri_footpath_t) * n_footpaths);
   }

--- a/src/abi.cc
+++ b/src/abi.cc
@@ -175,13 +175,11 @@ nigiri_route_t* nigiri_get_route(const nigiri_timetable_t* t, uint32_t idx) {
   auto stops = t->tt->route_location_seq_[ridx];
   auto route = new nigiri_route_t;
   auto const n_stops = stops.size();
+  route->stops = new nigiri_route_stop_t[n_stops];
   if (n_stops > 0) {
-    auto route_stops = new nigiri_route_stop_t[n_stops];
-    std::memcpy(route_stops, &stops.front(),
+    std::memcpy(route->stops, &stops.front(),
                 sizeof(nigiri_route_stop_t) * n_stops);
-    route->stops = route_stops;
   }
-
   route->n_stops = static_cast<uint16_t>(n_stops);
   route->clasz =
       static_cast<uint16_t>(t->tt->route_section_clasz_[ridx].front());
@@ -213,8 +211,8 @@ nigiri_location_t* nigiri_get_location_with_footpaths(
                        ? t->tt->locations_.footpaths_in_[0][lidx]
                        : t->tt->locations_.footpaths_out_[0][lidx];
   auto const n_footpaths = footpaths.size();
+  location->footpaths = new nigiri_footpath_t[n_footpaths];
   if (n_footpaths > 0) {
-    location->footpaths = new nigiri_footpath_t[n_footpaths];
     std::memcpy(location->footpaths, &footpaths.front(),
                 sizeof(nigiri_footpath_t) * n_footpaths);
   }
@@ -232,6 +230,7 @@ nigiri_location_t* nigiri_get_location(const nigiri_timetable_t* t,
 }
 
 void nigiri_destroy_location(const nigiri_location_t* location) {
+  delete[] location->footpaths;
   delete location;
 }
 

--- a/src/abi.cc
+++ b/src/abi.cc
@@ -164,6 +164,10 @@ bool nigiri_is_transport_active(const nigiri_timetable_t* t,
   return t->tt->bitfields_[t->tt->transport_traffic_days_[tidx]].test(day_idx);
 }
 
+uint32_t nigiri_get_route_count(const nigiri_timetable_t* t) {
+  return t->tt->n_routes();
+}
+
 nigiri_route_t* nigiri_get_route(const nigiri_timetable_t* t, uint32_t idx) {
   auto const ridx = nigiri::route_idx_t{idx};
   auto stops = t->tt->route_location_seq_[ridx];

--- a/src/abi.cc
+++ b/src/abi.cc
@@ -7,6 +7,7 @@
 #include "date/date.h"
 
 #include "utl/helpers/algorithm.h"
+#include "utl/overloaded.h"
 #include "utl/progress_tracker.h"
 #include "utl/verify.h"
 
@@ -23,6 +24,11 @@
 #include "nigiri/timetable.h"
 #include "nigiri/types.h"
 
+#include "nigiri/routing/journey.h"
+#include "nigiri/routing/raptor/raptor.h"
+#include "nigiri/routing/search.h"
+#include "nigiri/rt/frun.h"
+
 #include "nigiri/common/interval.h"
 #include "cista/memory_holder.h"
 
@@ -35,7 +41,8 @@ struct nigiri_timetable {
 
 nigiri_timetable_t* nigiri_load_from_dir(nigiri::loader::dir const& d,
                                          int64_t from_ts,
-                                         int64_t to_ts) {
+                                         int64_t to_ts,
+                                         unsigned link_stop_distance) {
   auto loaders =
       std::vector<std::unique_ptr<nigiri::loader::loader_interface>>{};
   loaders.emplace_back(std::make_unique<nigiri::loader::gtfs::gtfs_loader>());
@@ -49,6 +56,7 @@ nigiri_timetable_t* nigiri_load_from_dir(nigiri::loader::dir const& d,
       std::make_unique<nigiri::loader::hrd::hrd_5_20_avv_loader>());
 
   auto const src = nigiri::source_idx_t{0U};
+  const std::string_view default_timezone_{"Europe/Berlin"};
 
   auto const c =
       utl::find_if(loaders, [&](auto&& l) { return l->applicable(d); });
@@ -67,7 +75,8 @@ nigiri_timetable_t* nigiri_load_from_dir(nigiri::loader::dir const& d,
   nigiri::loader::register_special_stations(*t->tt);
   auto local_bitfield_indices =
       nigiri::hash_map<nigiri::bitfield, nigiri::bitfield_idx_t>{};
-  (*c)->load({}, src, d, *t->tt, local_bitfield_indices, nullptr, nullptr);
+  (*c)->load({.link_stop_distance_ = link_stop_distance,
+              .default_tz_ = default_timezone_}, src, d, *t->tt, local_bitfield_indices, nullptr, nullptr);
   nigiri::loader::finalize(*t->tt);
 
   t->rtt = std::make_shared<nigiri::rt_timetable>(
@@ -78,12 +87,19 @@ nigiri_timetable_t* nigiri_load_from_dir(nigiri::loader::dir const& d,
 nigiri_timetable_t* nigiri_load(const char* path,
                                 int64_t from_ts,
                                 int64_t to_ts) {
+  return nigiri_load_linking_stops(path, from_ts, to_ts, 0);
+}
+
+nigiri_timetable_t* nigiri_load_linking_stops(const char* path,
+                                              int64_t from_ts,
+                                              int64_t to_ts,
+                                              unsigned link_stop_distance) {
   auto const progress_tracker = utl::activate_progress_tracker("libnigiri");
   auto const silencer = utl::global_progress_bars{true};
 
   auto const tt_path = std::filesystem::path{path};
   auto const d = nigiri::loader::make_dir(tt_path);
-  return nigiri_load_from_dir(*d, from_ts, to_ts);
+  return nigiri_load_from_dir(*d, from_ts, to_ts, link_stop_distance);
 }
 
 void nigiri_destroy(const nigiri_timetable_t* t) { delete t; }
@@ -174,8 +190,8 @@ uint32_t nigiri_get_location_count(const nigiri_timetable_t* t) {
   return t->tt->n_locations();
 }
 
-nigiri_location_t* nigiri_get_location(const nigiri_timetable_t* t,
-                                       uint32_t idx) {
+nigiri_location_t* nigiri_get_location_with_footpaths(
+    const nigiri_timetable_t* t, uint32_t idx, bool incoming_footpaths) {
   auto const lidx = nigiri::location_idx_t{idx};
   auto location = new nigiri_location_t;
   auto l = t->tt->locations_.get(lidx);
@@ -186,11 +202,22 @@ nigiri_location_t* nigiri_get_location(const nigiri_timetable_t* t,
   location->lat = l.pos_.lat_;
   location->lon = l.pos_.lng_;
   location->transfer_time = static_cast<uint16_t>(l.transfer_time_.count());
+  auto footpaths = incoming_footpaths
+                       ? t->tt->locations_.footpaths_in_[0][lidx]
+                       : t->tt->locations_.footpaths_out_[0][lidx];
+  location->footpaths =
+      reinterpret_cast<nigiri_footpath_t*>(&footpaths.front()); // TODO
+  location->n_footpaths = footpaths.size();
   location->parent =
       l.parent_ == nigiri::location_idx_t::invalid()
           ? 0
           : static_cast<nigiri::location_idx_t::value_t>(l.parent_);
   return location;
+}
+
+nigiri_location_t* nigiri_get_location(const nigiri_timetable_t* t,
+                                       uint32_t idx) {
+  return nigiri_get_location_with_footpaths(t, idx, false);
 }
 
 void nigiri_destroy_location(const nigiri_location_t* location) {
@@ -207,16 +234,19 @@ void nigiri_update_with_rt_from_buf(const nigiri_timetable_t* t,
 
   auto const rtt_callback =
       [&](nigiri::transport const transport, nigiri::stop_idx_t const stop_idx,
-          nigiri::event_type const ev_type, nigiri::duration_t const delay,
-          bool const cancelled) {
+          nigiri::event_type const ev_type,
+          nigiri::location_idx_t const location_idx, int16_t in_out_allowed,
+          nigiri::duration_t const delay) {
         nigiri_event_change_t const c = {
             .transport_idx =
                 static_cast<nigiri::transport_idx_t::value_t>(transport.t_idx_),
             .day_idx = static_cast<nigiri::day_idx_t::value_t>(transport.day_),
             .stop_idx = stop_idx,
             .is_departure = ev_type != nigiri::event_type::kArr,
-            .delay = delay.count(),
-            .cancelled = cancelled};
+            .location_idx =
+                static_cast<nigiri::location_idx_t::value_t>(location_idx),
+            .in_out_allowed = in_out_allowed,
+            .delay = delay.count()};
         callback(c, context);
       };
 
@@ -240,4 +270,122 @@ void nigiri_update_with_rt(const nigiri_timetable_t* t,
                            void* context) {
   auto const file = cista::mmap{gtfsrt_pb_path, cista::mmap::protection::READ};
   return nigiri_update_with_rt_from_buf(t, file.view(), callback, context);
+}
+
+nigiri::pareto_set<nigiri::routing::journey> raptor_search(
+    nigiri::timetable const& tt,
+    nigiri::rt_timetable const* rtt,
+    nigiri::routing::query q,
+    bool backward_search) {
+  static auto search_state = nigiri::routing::search_state{};
+  static auto algo_state = nigiri::routing::raptor_state{};
+  if (backward_search) {
+    using algo_t = nigiri::routing::raptor<nigiri::direction::kBackward, true>;
+    return *(nigiri::routing::search<nigiri::direction::kBackward, algo_t>{
+        tt, rtt, search_state, algo_state, std::move(q)}
+                 .execute()
+                 .journeys_);
+  } else {
+    using algo_t = nigiri::routing::raptor<nigiri::direction::kForward, true>;
+    return *(nigiri::routing::search<nigiri::direction::kForward, algo_t>{
+        tt, rtt, search_state, algo_state, std::move(q)}
+                 .execute()
+                 .journeys_);
+  }
+}
+
+nigiri_pareto_set_t* nigiri_get_journeys(const nigiri_timetable_t* t,
+                                         uint32_t start_location_idx,
+                                         uint32_t destination_location_idx,
+                                         int64_t time,
+                                         bool backward_search) {
+  using namespace date;
+  using namespace nigiri;
+  auto q = nigiri::routing::query{
+      .start_time_ = floor<std::chrono::minutes>(
+          std::chrono::system_clock::from_time_t(static_cast<time_t>(time))),
+      .start_ = {{nigiri::location_idx_t{start_location_idx}, 0_minutes, 0U}},
+      .destination_ = {{nigiri::location_idx_t{destination_location_idx},
+                        0_minutes, 0U}},
+      .prf_idx_ = 0};
+
+  auto journeys = raptor_search(*t->tt, t->rtt.get(), q, backward_search);
+  auto const n_journeys =
+      static_cast<std::size_t>(std::distance(journeys.begin(), journeys.end()));
+  auto js = new nigiri_journey_t[n_journeys];
+
+  auto const pareto_set = new nigiri_pareto_set_t;
+  pareto_set->n_journeys = n_journeys;
+  pareto_set->journeys = js;
+
+  auto i = 0;
+  for (auto it = journeys.begin(); it != journeys.end(); it++, i++) {
+    js[i].n_legs = it->legs_.size();
+    js[i].legs = new nigiri_leg_t[it->legs_.size()];
+    js[i].start_time = std::chrono::system_clock::to_time_t(it->start_time_);
+    js[i].dest_time = std::chrono::system_clock::to_time_t(it->dest_time_);
+
+    for (auto const [j, leg] : utl::enumerate(it->legs_)) {
+      auto const l = &js[i].legs[j];
+
+      auto const set_run =
+          [&](nigiri::routing::journey::run_enter_exit const& run) {
+            auto const frun = nigiri::rt::frun{*t->tt, t->rtt.get(), run.r_};
+            auto const from = frun[run.stop_range_.from_];
+            auto const to = frun[run.stop_range_.to_ - 1U];
+            l->is_footpath = false;
+            l->transport_idx =
+                run.r_.is_scheduled()
+                    ? static_cast<nigiri::transport_idx_t::value_t>(
+                          run.r_.t_.t_idx_)
+                    : 0;
+            l->day_idx =
+                run.r_.is_scheduled()
+                    ? static_cast<nigiri::day_idx_t::value_t>(run.r_.t_.day_)
+                    : 0;
+            l->from_stop_idx = run.stop_range_.from_;
+            l->from_location_idx = static_cast<nigiri::location_idx_t::value_t>(
+                from.get_location_idx());
+            l->to_stop_idx = run.stop_range_.to_ - 1U;
+            l->to_location_idx = static_cast<nigiri::location_idx_t::value_t>(
+                to.get_location_idx());
+            l->duration = (to.time(nigiri::event_type::kArr) -
+                           from.time(nigiri::event_type::kDep))
+                              .count();
+          };
+      auto const set_footpath = [&, leg = leg](nigiri::footpath const fp) {
+        l->is_footpath = true;
+        l->transport_idx = 0;
+        l->day_idx = 0, l->from_stop_idx = 0;
+        l->from_location_idx =
+            static_cast<nigiri::location_idx_t::value_t>(leg.from_);
+        l->to_stop_idx = 0;
+        l->to_location_idx =
+            static_cast<nigiri::location_idx_t::value_t>(leg.to_);
+        l->duration = fp.duration().count();
+      };
+      auto const set_offset = [&, leg = leg](nigiri::routing::offset const x) {
+        l->is_footpath = true;
+        l->transport_idx = 0;
+        l->day_idx = 0;
+        l->from_stop_idx = 0;
+        l->from_location_idx =
+            static_cast<nigiri::location_idx_t::value_t>(leg.from_);
+        l->to_stop_idx = 0;
+        l->to_location_idx =
+            static_cast<nigiri::location_idx_t::value_t>(leg.to_);
+        l->duration = x.duration().count();
+      };
+      std::visit(utl::overloaded{set_run, set_footpath, set_offset}, leg.uses_);
+    }
+  }
+  return pareto_set;
+}
+
+void nigiri_destroy_journeys(const nigiri_pareto_set_t* journeys) {
+  for (int i = 0; i < journeys->n_journeys; i++) {
+    delete[] journeys->journeys[i].legs;
+  }
+  delete[] journeys->journeys;
+  delete journeys;
 }

--- a/src/abi.cc
+++ b/src/abi.cc
@@ -245,18 +245,20 @@ void nigiri_update_with_rt_from_buf(const nigiri_timetable_t* t,
   auto const rtt_callback =
       [&](nigiri::transport const transport, nigiri::stop_idx_t const stop_idx,
           nigiri::event_type const ev_type,
-          nigiri::location_idx_t const location_idx, int16_t in_out_allowed,
-          nigiri::duration_t const delay) {
+          std::optional<nigiri::location_idx_t> const location_idx,
+          std::optional<bool> in_out_allowed,
+          std::optional<nigiri::duration_t> const delay) {
         nigiri_event_change_t const c = {
             .transport_idx =
                 static_cast<nigiri::transport_idx_t::value_t>(transport.t_idx_),
             .day_idx = static_cast<nigiri::day_idx_t::value_t>(transport.day_),
             .stop_idx = stop_idx,
             .is_departure = ev_type != nigiri::event_type::kArr,
-            .location_idx =
-                static_cast<nigiri::location_idx_t::value_t>(location_idx),
-            .in_out_allowed = in_out_allowed,
-            .delay = delay.count()};
+            .stop_change = !delay.has_value(),
+            .stop_location_idx = static_cast<nigiri::location_idx_t::value_t>(
+                location_idx.value_or(nigiri::location_idx_t::invalid())),
+            .stop_in_out_allowed = in_out_allowed.value_or(true),
+            .delay = delay.value_or(nigiri::duration_t{0}).count()};
         callback(c, context);
       };
 

--- a/src/rt/gtfsrt_update.cc
+++ b/src/rt/gtfsrt_update.cc
@@ -63,20 +63,6 @@ std::string remove_nl(std::string s) {
   return s;
 }
 
-void dispatch_event_change(rt_timetable& rtt,
-                           run const& r,
-                           stop_idx_t const stop_idx,
-                           event_type const ev_type,
-                           location_idx_t const location_idx,
-                           int16_t const in_out_allowed,
-                           duration_t const delay) {
-  if ((ev_type == event_type::kArr && stop_idx != r.stop_range_.from_) ||
-      (ev_type == event_type::kDep && stop_idx != r.stop_range_.to_ - 1)) {
-    rtt.dispatch_event_change(r.t_, stop_idx, ev_type, location_idx,
-                              in_out_allowed, delay);
-  }
-}
-
 delay_propagation update_delay(timetable const& tt,
                                rt_timetable& rtt,
                                run const& r,
@@ -89,8 +75,8 @@ delay_propagation update_delay(timetable const& tt,
                                           ? std::max(*min, static_time + delay)
                                           : static_time + delay;
   rtt.update_time(r.rt_, stop_idx, ev_type, lower_bounded_new_time);
-  dispatch_event_change(rtt, r, stop_idx, ev_type, location_idx_t{0}, -1,
-                        lower_bounded_new_time - static_time);
+  rtt.dispatch_delay(r, stop_idx, ev_type,
+                     lower_bounded_new_time - static_time);
   return {rtt.unix_event_time(r.rt_, stop_idx, ev_type), delay};
 }
 
@@ -114,8 +100,8 @@ delay_propagation update_event(timetable const& tt,
     auto const lower_bounded_new_time =
         pred_time.has_value() ? std::max(*pred_time, new_time) : new_time;
     rtt.update_time(r.rt_, stop_idx, ev_type, lower_bounded_new_time);
-    dispatch_event_change(rtt, r, stop_idx, ev_type, location_idx_t{0}, -1,
-                          lower_bounded_new_time - static_time);
+    rtt.dispatch_delay(r, stop_idx, ev_type,
+                       lower_bounded_new_time - static_time);
     return {lower_bounded_new_time, new_time - static_time};
   }
 }
@@ -131,10 +117,8 @@ void cancel_run(timetable const&, rt_timetable& rtt, run& r) {
         bitfield_idx_t{rtt.bitfields_.size() - 1U};
 
     for (auto i = r.stop_range_.from_; i != r.stop_range_.to_; ++i) {
-      dispatch_event_change(rtt, r, i, event_type::kArr, location_idx_t{0}, 0,
-                            duration_t{0});
-      dispatch_event_change(rtt, r, i, event_type::kDep, location_idx_t{0}, 0,
-                            duration_t{0});
+      rtt.dispatch_stop_change(r, i, event_type::kArr, std::nullopt, false);
+      rtt.dispatch_stop_change(r, i, event_type::kDep, std::nullopt, false);
     }
   }
 }
@@ -183,13 +167,11 @@ void update_run(
       auto& stp = rtt.rt_transport_location_seq_[r.rt_][stop_idx];
       if (upd_it->schedule_relationship() ==
           gtfsrt::TripUpdate_StopTimeUpdate_ScheduleRelationship_SKIPPED) {
+        auto l_idx = stop{stp}.location_idx();
         // Cancel skipped stops (in_allowed = out_allowed = false).
-        stp =
-            stop{stop{stp}.location_idx(), false, false, false, false}.value();
-        dispatch_event_change(rtt, r, stop_idx, event_type::kArr,
-                              location_idx_t{0}, 0, duration_t{0});
-        dispatch_event_change(rtt, r, stop_idx, event_type::kDep,
-                              location_idx_t{0}, 0, duration_t{0});
+        stp = stop{l_idx, false, false, false, false}.value();
+        rtt.dispatch_stop_change(r, stop_idx, event_type::kArr, l_idx, false);
+        rtt.dispatch_stop_change(r, stop_idx, event_type::kDep, l_idx, false);
       } else if (upd_it->stop_time_properties().has_assigned_stop_id() ||
                  (upd_it->has_stop_id() &&
                   upd_it->stop_id() !=
@@ -212,10 +194,10 @@ void update_run(
           if (utl::find(transports, r.rt_) == end(transports)) {
             transports.push_back(r.rt_);
           }
-          dispatch_event_change(rtt, r, stop_idx, event_type::kArr,
-                                l_it->second, -1, duration_t{0});
-          dispatch_event_change(rtt, r, stop_idx, event_type::kDep,
-                                l_it->second, -1, duration_t{0});
+          rtt.dispatch_stop_change(r, stop_idx, event_type::kArr, l_it->second,
+                                   s.out_allowed());
+          rtt.dispatch_stop_change(r, stop_idx, event_type::kDep, l_it->second,
+                                   s.in_allowed());
         } else {
           log(log_lvl::error, "gtfsrt.stop_assignment",
               "stop assignment: src={}, stop_id=\"{}\" not found", src, new_id);
@@ -225,12 +207,12 @@ void update_run(
         if (location_seq[stop_idx] != stp) {
           stp = location_seq[stop_idx];
           auto reset_stop = stop{stp};
-          dispatch_event_change(
-              rtt, r, stop_idx, event_type::kArr, reset_stop.location_idx(),
-              reset_stop.out_allowed() ? 1 : 0, duration_t{0});
-          dispatch_event_change(rtt, r, stop_idx, event_type::kDep,
-                                reset_stop.location_idx(),
-                                reset_stop.in_allowed() ? 1 : 0, duration_t{0});
+          rtt.dispatch_stop_change(r, stop_idx, event_type::kArr,
+                                   reset_stop.location_idx(),
+                                   reset_stop.out_allowed());
+          rtt.dispatch_stop_change(r, stop_idx, event_type::kDep,
+                                   reset_stop.location_idx(),
+                                   reset_stop.in_allowed());
         }
       }
     }

--- a/src/rt/vdv/vdv_update.cc
+++ b/src/rt/vdv/vdv_update.cc
@@ -332,8 +332,7 @@ void update_event(rt_timetable& rtt,
             et == event_type::kArr ? "ARR" : "DEP", rs.scheduled_time(et),
             delay.count() >= 0 ? "+" : "", delay.count());
   rtt.update_time(rs.fr_->rt_, rs.stop_idx_, et, new_time);
-  rtt.dispatch_event_change(rs.fr_->t_, rs.stop_idx_, et, location_idx_t{0},
-                            false, delay);
+  rtt.dispatch_delay(*rs.fr_, rs.stop_idx_, et, delay);
   if (delay_propagation != nullptr) {
     *delay_propagation = delay;
   }
@@ -373,8 +372,7 @@ void updater::update_run(rt_timetable& rtt,
               et == event_type::kArr ? "ARR" : "DEP", rs.scheduled_time(et),
               delay->count() >= 0 ? "+" : "", delay->count());
     rtt.update_time(fr.rt_, rs.stop_idx_, et, rs.scheduled_time(et) + *delay);
-    rtt.dispatch_event_change(fr.t_, rs.stop_idx_, et, location_idx_t{0}, false,
-                              *delay);
+    rtt.dispatch_delay(fr, rs.stop_idx_, et, *delay);
     ++stats_.propagated_delays_;
   };
 

--- a/src/rt/vdv/vdv_update.cc
+++ b/src/rt/vdv/vdv_update.cc
@@ -332,7 +332,7 @@ void update_event(rt_timetable& rtt,
             et == event_type::kArr ? "ARR" : "DEP", rs.scheduled_time(et),
             delay.count() >= 0 ? "+" : "", delay.count());
   rtt.update_time(rs.fr_->rt_, rs.stop_idx_, et, new_time);
-  rtt.dispatch_event_change(rs.fr_->t_, rs.stop_idx_, et, delay, false);
+  rtt.dispatch_event_change(rs.fr_->t_, rs.stop_idx_, et, location_idx_t{0}, false, delay);
   if (delay_propagation != nullptr) {
     *delay_propagation = delay;
   }
@@ -372,7 +372,7 @@ void updater::update_run(rt_timetable& rtt,
               et == event_type::kArr ? "ARR" : "DEP", rs.scheduled_time(et),
               delay->count() >= 0 ? "+" : "", delay->count());
     rtt.update_time(fr.rt_, rs.stop_idx_, et, rs.scheduled_time(et) + *delay);
-    rtt.dispatch_event_change(fr.t_, rs.stop_idx_, et, *delay, false);
+    rtt.dispatch_event_change(fr.t_, rs.stop_idx_, et, location_idx_t{0}, false, *delay);
     ++stats_.propagated_delays_;
   };
 

--- a/src/rt/vdv/vdv_update.cc
+++ b/src/rt/vdv/vdv_update.cc
@@ -332,7 +332,8 @@ void update_event(rt_timetable& rtt,
             et == event_type::kArr ? "ARR" : "DEP", rs.scheduled_time(et),
             delay.count() >= 0 ? "+" : "", delay.count());
   rtt.update_time(rs.fr_->rt_, rs.stop_idx_, et, new_time);
-  rtt.dispatch_event_change(rs.fr_->t_, rs.stop_idx_, et, location_idx_t{0}, false, delay);
+  rtt.dispatch_event_change(rs.fr_->t_, rs.stop_idx_, et, location_idx_t{0},
+                            false, delay);
   if (delay_propagation != nullptr) {
     *delay_propagation = delay;
   }
@@ -372,7 +373,8 @@ void updater::update_run(rt_timetable& rtt,
               et == event_type::kArr ? "ARR" : "DEP", rs.scheduled_time(et),
               delay->count() >= 0 ? "+" : "", delay->count());
     rtt.update_time(fr.rt_, rs.stop_idx_, et, rs.scheduled_time(et) + *delay);
-    rtt.dispatch_event_change(fr.t_, rs.stop_idx_, et, location_idx_t{0}, false, *delay);
+    rtt.dispatch_event_change(fr.t_, rs.stop_idx_, et, location_idx_t{0}, false,
+                              *delay);
     ++stats_.propagated_delays_;
   };
 

--- a/test/abi_test.cc
+++ b/test/abi_test.cc
@@ -2,6 +2,7 @@
 
 #include "date/date.h"
 
+#include <cstdint>
 #include "nigiri/loader/dir.h"
 #include "nigiri/abi.h"
 #include "nigiri/rt/util.h"
@@ -446,78 +447,89 @@ TEST(rt, abi_timetable) {
     EXPECT_EQ(6, evt.day_idx);
 
     if (*test_event_change_counter_ptr == 0) {
-      EXPECT_EQ(-1, evt.in_out_allowed);
-      EXPECT_EQ(0, evt.location_idx);
+      EXPECT_EQ(false, evt.stop_change);
+      EXPECT_EQ(true, evt.stop_in_out_allowed);
+      EXPECT_EQ(UINT32_MAX, evt.stop_location_idx);
       EXPECT_EQ(14, evt.stop_idx);
       EXPECT_EQ(false, evt.is_departure);
       EXPECT_EQ(1, evt.delay);
     }
     if (*test_event_change_counter_ptr == 1) {
-      EXPECT_EQ(-1, evt.in_out_allowed);
-      EXPECT_EQ(0, evt.location_idx);
+      EXPECT_EQ(false, evt.stop_change);
+      EXPECT_EQ(true, evt.stop_in_out_allowed);
+      EXPECT_EQ(UINT32_MAX, evt.stop_location_idx);
       EXPECT_EQ(14, evt.stop_idx);
       EXPECT_EQ(true, evt.is_departure);
       EXPECT_EQ(1, evt.delay);
     }
     if (*test_event_change_counter_ptr == 8) {
-      EXPECT_EQ(-1, evt.in_out_allowed);
-      EXPECT_EQ(0, evt.location_idx);
+      EXPECT_EQ(false, evt.stop_change);
+      EXPECT_EQ(true, evt.stop_in_out_allowed);
+      EXPECT_EQ(UINT32_MAX, evt.stop_location_idx);
       EXPECT_EQ(18, evt.stop_idx);
       EXPECT_EQ(false, evt.is_departure);
       EXPECT_EQ(2, evt.delay);
     }
     if (*test_event_change_counter_ptr == 9) {
-      EXPECT_EQ(-1, evt.in_out_allowed);
-      EXPECT_EQ(0, evt.location_idx);
+      EXPECT_EQ(false, evt.stop_change);
+      EXPECT_EQ(true, evt.stop_in_out_allowed);
+      EXPECT_EQ(UINT32_MAX, evt.stop_location_idx);
       EXPECT_EQ(18, evt.stop_idx);
       EXPECT_EQ(true, evt.is_departure);
       EXPECT_EQ(2, evt.delay);
     }
     if (*test_event_change_counter_ptr == 22) {
-      EXPECT_EQ(-1, evt.in_out_allowed);
-      EXPECT_EQ(35, evt.location_idx);
+      EXPECT_EQ(true, evt.stop_change);
+      EXPECT_EQ(true, evt.stop_in_out_allowed);
+      EXPECT_EQ(35, evt.stop_location_idx);
       EXPECT_EQ(25, evt.stop_idx);
       EXPECT_EQ(false, evt.is_departure);
       EXPECT_EQ(0, evt.delay);
     }
     if (*test_event_change_counter_ptr == 23) {
-      EXPECT_EQ(-1, evt.in_out_allowed);
-      EXPECT_EQ(35, evt.location_idx);
+      EXPECT_EQ(true, evt.stop_change);
+      EXPECT_EQ(true, evt.stop_in_out_allowed);
+      EXPECT_EQ(35, evt.stop_location_idx);
       EXPECT_EQ(25, evt.stop_idx);
       EXPECT_EQ(true, evt.is_departure);
       EXPECT_EQ(0, evt.delay);
     }
     if (*test_event_change_counter_ptr == 24) {
-      EXPECT_EQ(-1, evt.in_out_allowed);
-      EXPECT_EQ(0, evt.location_idx);
+      EXPECT_EQ(false, evt.stop_change);
+      EXPECT_EQ(true, evt.stop_in_out_allowed);
+      EXPECT_EQ(UINT32_MAX, evt.stop_location_idx);
       EXPECT_EQ(25, evt.stop_idx);
       EXPECT_EQ(false, evt.is_departure);
       EXPECT_EQ(-1, evt.delay);
     }
     if (*test_event_change_counter_ptr == 25) {
-      EXPECT_EQ(-1, evt.in_out_allowed);
-      EXPECT_EQ(0, evt.location_idx);
+      EXPECT_EQ(false, evt.stop_change);
+      EXPECT_EQ(true, evt.stop_in_out_allowed);
+      EXPECT_EQ(UINT32_MAX, evt.stop_location_idx);
       EXPECT_EQ(25, evt.stop_idx);
       EXPECT_EQ(true, evt.is_departure);
       EXPECT_EQ(-1, evt.delay);
     }
     if (*test_event_change_counter_ptr == 26) {
-      EXPECT_EQ(0, evt.in_out_allowed);
-      EXPECT_EQ(0, evt.location_idx);
+      EXPECT_EQ(true, evt.stop_change);
+      EXPECT_EQ(false, evt.stop_in_out_allowed);
+      EXPECT_EQ(35, evt.stop_location_idx);
       EXPECT_EQ(26, evt.stop_idx);
       EXPECT_EQ(false, evt.is_departure);
       EXPECT_EQ(0, evt.delay);
     }
     if (*test_event_change_counter_ptr == 27) {
-      EXPECT_EQ(0, evt.in_out_allowed);
-      EXPECT_EQ(0, evt.location_idx);
+      EXPECT_EQ(true, evt.stop_change);
+      EXPECT_EQ(false, evt.stop_in_out_allowed);
+      EXPECT_EQ(35, evt.stop_location_idx);
       EXPECT_EQ(26, evt.stop_idx);
       EXPECT_EQ(true, evt.is_departure);
       EXPECT_EQ(0, evt.delay);
     }
     if (*test_event_change_counter_ptr == 30) {
-      EXPECT_EQ(-1, evt.in_out_allowed);
-      EXPECT_EQ(0, evt.location_idx);
+      EXPECT_EQ(false, evt.stop_change);
+      EXPECT_EQ(true, evt.stop_in_out_allowed);
+      EXPECT_EQ(UINT32_MAX, evt.stop_location_idx);
       EXPECT_EQ(27, evt.stop_idx);
       EXPECT_EQ(false, evt.is_departure);
       EXPECT_EQ(0, evt.delay);


### PR DESCRIPTION
This finally addresses most of the open todos from #66, among other things:
* handle RT track changes, in_allowed/out_allowed
* expose footpaths
* expose querying/journeys

There is one change I made that has an impact outside of the ABI: For absolute-time-based GTFSRTs (`ev.has_time()`), the time-travel-corrected time will be propagated in [L119](https://github.com/traines-source/nigiri/blob/aa4c837b46b62f69d94295d9cf92d2c2ad13bfa2/src/rt/gtfsrt_update.cc#L119) just like for delay-based GTFSRTs in [L94](https://github.com/traines-source/nigiri/blob/aa4c837b46b62f69d94295d9cf92d2c2ad13bfa2/src/rt/gtfsrt_update.cc#L94). I think this was a bug.