### PR TITLE
Fix test data for 'stop_times.txt'

### DIFF
--- a/test/loader/gtfs/stop_time_test.cc
+++ b/test/loader/gtfs/stop_time_test.cc
@@ -73,8 +73,8 @@ TEST(gtfs, read_stop_times_example_data) {
   EXPECT_EQ("S2", tt.locations_.ids_[stp.location_idx()].view());
   EXPECT_EQ(6_hours + 15_minutes, awe1_stop_times.arr_);
   EXPECT_EQ(6_hours + 15_minutes, awe1_stop_times.dep_);
-  EXPECT_FALSE(stp.out_allowed());
-  EXPECT_TRUE(stp.in_allowed());
+  EXPECT_FALSE(stp.in_allowed());
+  EXPECT_TRUE(stp.out_allowed());
 
   awe1_stop_times = trip_data.data_[awe1_it->second].event_times_[2];
   stp = stop{trip_data.data_[awe1_it->second].stop_seq_[2]};

--- a/test/loader/gtfs/test_data.cc
+++ b/test/loader/gtfs/test_data.cc
@@ -70,17 +70,17 @@ AWE1,20:30:00,28:00:00,420
 
 constexpr auto const example_stop_times_content =
     R"(trip_id,arrival_time,departure_time,stop_id,stop_sequence,pickup_type,drop_off_type
-AWD1,6:45,6:45,S6,6,0,0,0
-AWD1,,,S5,5,0,0,0
-AWD1,,,S4,4,0,0,0
-AWD1,6:20,6:20,S3,3,0,0,0
-AWD1,,,S2,2,0,0,0
-AWD1,6:10,6:10,S1,1,0,0,0
-AWE1,6:45,6:45,S6,5,0,0,0
-AWE1,,,S5,4,0,0,0
-AWE1,6:20,6:30,S3,3,0,0,0
-AWE1,,,S2,2,0,1,3
-AWE1,6:10,6:10,S1,1,0,0,0
+AWD1,6:45,6:45,S6,6,0,0
+AWD1,,,S5,5,0,0
+AWD1,,,S4,4,0,0
+AWD1,6:20,6:20,S3,3,0,0
+AWD1,,,S2,2,0,0
+AWD1,6:10,6:10,S1,1,0,0
+AWE1,6:45,6:45,S6,5,0,0
+AWE1,,,S5,4,0,0
+AWE1,6:20,6:30,S3,3,0,0
+AWE1,,,S2,2,1,3
+AWE1,6:10,6:10,S1,1,0,0
 )";
 
 loader::mem_dir example_files() {


### PR DESCRIPTION
The test data contained an additional column, that didn't correspond to any header.
For the changed test, I think this is the intended use case, as `pickup_type == 0` is checked multiple times.