### PR TITLE
Extends shapes to store bounding boxes

### DIFF
--- a/.pkg
+++ b/.pkg
@@ -9,7 +9,7 @@
 [geo]
   url=git@github.com:motis-project/geo.git
   branch=master
-  commit=0a14addf42e91b267906a156c9c2564935c03eaf
+  commit=463c4f97dde00ddbf0f3f8fafd93559a2027d61e
 [utl]
   url=git@github.com:motis-project/utl.git
   branch=master

--- a/include/nigiri/loader/gtfs/shape_prepare.h
+++ b/include/nigiri/loader/gtfs/shape_prepare.h
@@ -12,4 +12,6 @@ void calculate_shape_offsets(timetable const&,
                              vector_map<gtfs_trip_idx_t, trip> const&,
                              shape_loader_state const&);
 
+void calculate_shape_boxes(timetable const&, shapes_storage&);
+
 }  // namespace nigiri::loader::gtfs

--- a/include/nigiri/shape.h
+++ b/include/nigiri/shape.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <optional>
 #include <span>
 
 #include "cista/containers/pair.h"
@@ -24,9 +25,7 @@ struct shapes_storage {
   void add_trip_shape_offsets(
       trip_idx_t, cista::pair<shape_idx_t, shape_offset_idx_t> const&);
   geo::box get_bounding_box(route_idx_t) const;
-  geo::box get_bounding_box_or_else(route_idx_t,
-                                    std::size_t,
-                                    std::function<geo::box()> const&) const;
+  std::optional<geo::box> get_bounding_box(route_idx_t, std::size_t) const;
 
   mm_vecvec<shape_idx_t, geo::latlng> data_;
   mm_vecvec<shape_offset_idx_t, shape_offset_t> offsets_;

--- a/include/nigiri/shape.h
+++ b/include/nigiri/shape.h
@@ -5,6 +5,7 @@
 
 #include "cista/containers/pair.h"
 
+#include "geo/box.h"
 #include "geo/latlng.h"
 
 #include "nigiri/types.h"
@@ -22,11 +23,16 @@ struct shapes_storage {
   shape_offset_idx_t add_offsets(std::vector<shape_offset_t> const&);
   void add_trip_shape_offsets(
       trip_idx_t, cista::pair<shape_idx_t, shape_offset_idx_t> const&);
+  geo::box get_bounding_box(route_idx_t) const;
+  geo::box get_bounding_box_or_else(route_idx_t,
+                                    std::size_t,
+                                    std::function<geo::box()> const&) const;
 
   mm_vecvec<shape_idx_t, geo::latlng> data_;
   mm_vecvec<shape_offset_idx_t, shape_offset_t> offsets_;
   mm_vec_map<trip_idx_t, cista::pair<shape_idx_t, shape_offset_idx_t>>
       trip_offset_indices_;
+  mm_vecvec<route_idx_t, geo::box> boxes_;
 };
 
 }  // namespace nigiri

--- a/src/loader/gtfs/load_timetable.cc
+++ b/src/loader/gtfs/load_timetable.cc
@@ -367,6 +367,11 @@ void load_timetable(loader_config const& config,
       progress_tracker->increment();
     }
 
+    // Build bounding boxes
+    if (shapes_data != nullptr) {
+      calculate_shape_boxes(tt, *shapes_data);
+    }
+
     // Build location_routes map
     for (auto l = tt.location_routes_.size(); l != tt.n_locations(); ++l) {
       tt.location_routes_.emplace_back(location_routes[location_idx_t{l}]);

--- a/src/loader/gtfs/shape_prepare.cc
+++ b/src/loader/gtfs/shape_prepare.cc
@@ -161,8 +161,11 @@ void calculate_shape_boxes(timetable const& tt, shapes_storage& shapes_data) {
     });
   }
   // Create bounding boxes for all routes
-  for (auto const [i, claszes] : utl::enumerate(tt.route_section_clasz_)) {
-    auto const r = route_idx_t{i};
+  for (auto const r : tt.transport_route_) {
+    // Skip routes added with previous timetables
+    if  (r < shapes_data.boxes_.size()) {
+      continue;
+    }
     auto const seq = tt.route_location_seq_[r];
     assert(seq.size() > 0U);
     auto segment_boxes = std::vector<geo::box>(seq.size());

--- a/src/loader/gtfs/shape_prepare.cc
+++ b/src/loader/gtfs/shape_prepare.cc
@@ -138,10 +138,10 @@ void calculate_shape_boxes(timetable const& tt, shapes_storage& shapes_data) {
   auto cached_shape_boxes =
       hash_map<cista::pair<shape_idx_t, shape_offset_idx_t>,
                std::vector<geo::box>>{};
-  for (auto const r : tt.transport_route_ |
-                          std::views::filter([&](route_idx_t const route_idx) {
-                            return route_idx >= shapes_data.boxes_.size();
-                          })) {
+  auto const new_routes =
+      interval{static_cast<route_idx_t>(shapes_data.boxes_.size()),
+               static_cast<route_idx_t>(tt.route_transport_ranges_.size())};
+  for (auto const r : new_routes) {
     auto const seq = tt.route_location_seq_[r];
     assert(seq.size() > 0U);
     auto segment_boxes = std::vector<geo::box>(seq.size());

--- a/src/loader/gtfs/shape_prepare.cc
+++ b/src/loader/gtfs/shape_prepare.cc
@@ -166,7 +166,7 @@ void calculate_shape_boxes(timetable const& tt, shapes_storage& shapes_data) {
     auto const seq = tt.route_location_seq_[r];
     assert(seq.size() > 0U);
     auto segment_boxes = std::vector<geo::box>(seq.size());
-    auto nontrivial = 0U;
+    auto last_extend = 0U;
     // 0: bounding box for trip,  1-N: bounding box for segment
     auto& bounding_box = segment_boxes[0U];
     auto const stop_indices =
@@ -200,7 +200,7 @@ void calculate_shape_boxes(timetable const& tt, shapes_storage& shapes_data) {
             if (!box.contains(shape_box)) {
               bounding_box.extend(shape_box);
               box.extend(shape_box);
-              nontrivial = std::max(nontrivial, from + 1U);
+              last_extend = std::max(last_extend, from + 1U);
             }
           }
           prev_pos = next_pos;
@@ -208,7 +208,7 @@ void calculate_shape_boxes(timetable const& tt, shapes_storage& shapes_data) {
       });
     }
     // 0: bounding box for trip,  1-N: bounding box for segment
-    segment_boxes.resize(nontrivial + 1);
+    segment_boxes.resize(last_extend + 1);
     shapes_data.boxes_.emplace_back(segment_boxes);
   }
 }

--- a/src/loader/gtfs/shape_prepare.cc
+++ b/src/loader/gtfs/shape_prepare.cc
@@ -160,12 +160,11 @@ void calculate_shape_boxes(timetable const& tt, shapes_storage& shapes_data) {
       return segment_boxes;
     });
   }
-  // Create bounding boxes for all routes
-  for (auto const r : tt.transport_route_) {
-    // Skip routes added with previous timetables
-    if  (r < shapes_data.boxes_.size()) {
-      continue;
-    }
+  // Create bounding boxes for all routes not already added
+  for (auto const r : tt.transport_route_ |
+                          std::views::filter([&](route_idx_t const route_idx) {
+                            return route_idx >= shapes_data.boxes_.size();
+                          })) {
     auto const seq = tt.route_location_seq_[r];
     assert(seq.size() > 0U);
     auto segment_boxes = std::vector<geo::box>(seq.size());

--- a/src/shape.cc
+++ b/src/shape.cc
@@ -102,16 +102,15 @@ geo::box shapes_storage::get_bounding_box(route_idx_t const route_idx) const {
   return boxes_[route_idx][0];
 }
 
-geo::box shapes_storage::get_bounding_box_or_else(
-    nigiri::route_idx_t const route_idx,
-    std::size_t const segment,
-    std::function<geo::box()> const& callback) const {
+std::optional<geo::box> shapes_storage::get_bounding_box(
+    nigiri::route_idx_t const route_idx, std::size_t const segment) const {
 
   utl::verify(route_idx < boxes_.size(), "Route index {} is out of bounds",
               route_idx);
   auto const& boxes = boxes_[route_idx];
   // 1-N: bounding box for segment
-  return segment + 1 < boxes.size() ? boxes[segment + 1] : callback();
+  return segment + 1 < boxes.size() ? boxes[segment + 1]
+                                    : std::optional<geo::box>{};
 }
 
 }  // namespace nigiri

--- a/test/shape_test.cc
+++ b/test/shape_test.cc
@@ -183,7 +183,6 @@ TEST(shape, single_trip_with_shape) {
     }
     // Shape contained in bounding box
     {
-
       EXPECT_FALSE(shapes_data.get_bounding_box(route_idx_t{2}, 4).has_value());
     }
   }

--- a/test/shape_test.cc
+++ b/test/shape_test.cc
@@ -169,18 +169,22 @@ TEST(shape, single_trip_with_shape) {
     EXPECT_EQ((geo::make_box({{4.0, 1.9}, {6.0, 5.0}})),
               shapes_data.get_bounding_box(route_idx_t{2U}));
     // Bounding boxes for segments
-    auto const kTestBox = geo::make_box({{90.0, 45.0}});
-    auto const fallback = [&]() { return kTestBox; };
     // Bounding box extended by shape
-    EXPECT_EQ(
-        (geo::make_box({{5.0, 2.0}, {6.0, 3.0}})),
-        shapes_data.get_bounding_box_or_else(route_idx_t{2}, 2, fallback));
-    EXPECT_EQ(
-        (geo::make_box({{4.0, 1.9}, {5.0, 2.0}})),
-        shapes_data.get_bounding_box_or_else(route_idx_t{2}, 3, fallback));
+    {
+      auto const extended_by_shape =
+          shapes_data.get_bounding_box(route_idx_t{2}, 3);
+      ASSERT_TRUE(extended_by_shape.has_value());
+      EXPECT_EQ((geo::make_box({{4.0, 1.9}, {5.0, 2.0}})), *extended_by_shape);
 
+      auto const before_last_extend =
+          shapes_data.get_bounding_box(route_idx_t{2}, 2);
+      ASSERT_TRUE(before_last_extend.has_value());
+      EXPECT_EQ((geo::make_box({{5.0, 2.0}, {6.0, 3.0}})), *before_last_extend);
+    }
     // Shape contained in bounding box
-    EXPECT_EQ(kTestBox, shapes_data.get_bounding_box_or_else(route_idx_t{2}, 4,
-                                                             fallback));
+    {
+
+      EXPECT_FALSE(shapes_data.get_bounding_box(route_idx_t{2}, 4).has_value());
+    }
   }
 }


### PR DESCRIPTION
Extend `shapes_storage` to contain bounding boxes for all routes and each segment. Bounding boxes, that can trivially be created by their corresponding stations only will not be stored, however, to save disk space.
This change is related to motis-project/motis#603, simplifying its implementation.