### PR TITLE
Expand intermodal footpaths before other footpaths

### DIFF
--- a/include/nigiri/routing/raptor/raptor.h
+++ b/include/nigiri/routing/raptor/raptor.h
@@ -220,9 +220,9 @@ struct raptor {
       utl::fill(state_.station_mark_.blocks_, 0U);
 
       update_transfers(k);
+      update_intermodal_footpaths(k);
       update_footpaths(k, prf_idx);
       update_td_offsets(k, prf_idx);
-      update_intermodal_footpaths(k);
 
       trace_print_state_after_round();
     }


### PR DESCRIPTION
Before: At the end of a connection, timetable footpaths could be used to reach other stations + intermodal footpaths from these other stations to the destination.

After: Timetable footpaths can no longer be used directly before intermodal footpaths at the end.