### PR TITLE
Fix buffer overflow when creating bounding boxes

### DIFF
--- a/src/loader/gtfs/shape_prepare.cc
+++ b/src/loader/gtfs/shape_prepare.cc
@@ -274,8 +274,8 @@ void assign_bounding_boxes(timetable const& tt,
         auto const& bboxes = res.segment_bboxes_;
         if (!bboxes.empty()) {
           for (auto const [i, bbox] : utl::enumerate(bboxes)) {
-            segment_bboxes[i + cista::to_idx(absolute_range.from_)].extend(
-                bbox);
+            segment_bboxes.at(i + cista::to_idx(absolute_range.from_))
+                .extend(bbox);
           }
           is_trivial = false;
         }

--- a/src/loader/gtfs/stop_time.cc
+++ b/src/loader/gtfs/stop_time.cc
@@ -99,10 +99,10 @@ void read_stop_times(timetable& tt,
           t->requires_sorting_ |= (!t->seq_numbers_.empty() &&
                                    t->seq_numbers_.back() > *s.stop_sequence_);
 
-          t->seq_numbers_.emplace_back(*s.stop_sequence_);
           t->stop_seq_.push_back(stop{stops.at(s.stop_id_->view()), in_allowed,
                                       out_allowed, in_allowed, out_allowed}
                                      .value());
+          t->seq_numbers_.emplace_back(*s.stop_sequence_);
           t->event_times_.emplace_back(
               stop_events{.arr_ = arrival_time, .dep_ = departure_time});
           if (store_distances) {


### PR DESCRIPTION
Using a GTFS feed, that is missing a 'stop_id' in 'stops.txt', could led to a buffer overflow when creating bounding boxes.