### PR TITLE
Add setting for disposable time between transfers

### DIFF
--- a/include/nigiri/routing/search.h
+++ b/include/nigiri/routing/search.h
@@ -87,7 +87,7 @@ struct search {
 
     tts.factor_ = std::max(tts.factor_, 1.0F);
     if (tts.factor_ == 1.0F && tts.min_transfer_time_ == 0_minutes &&
-        tts.disposable_time_ == 0_minutes) {
+        tts.additional_time_ == 0_minutes) {
       tts.default_ = true;
     }
 

--- a/include/nigiri/routing/search.h
+++ b/include/nigiri/routing/search.h
@@ -86,10 +86,11 @@ struct search {
                 kMaxVias);
 
     tts.factor_ = std::max(tts.factor_, 1.0F);
-    if (tts.factor_ == 1.0F && tts.min_transfer_time_ == 0_minutes &&
-        tts.additional_time_ == 0_minutes) {
-      tts.default_ = true;
-    }
+    tts.min_transfer_time_ = std::max(tts.min_transfer_time_, 0_minutes);
+    tts.additional_time_ = std::max(tts.additional_time_, 0_minutes);
+    tts.default_ = tts.factor_ == 1.0F  //
+                   && tts.min_transfer_time_ == 0_minutes  //
+                   && tts.additional_time_ == 0_minutes;
 
     collect_destinations(tt_, q_.destination_, q_.dest_match_mode_,
                          state_.is_destination_, state_.dist_to_dest_);

--- a/include/nigiri/routing/search.h
+++ b/include/nigiri/routing/search.h
@@ -86,7 +86,8 @@ struct search {
                 kMaxVias);
 
     tts.factor_ = std::max(tts.factor_, 1.0F);
-    if (tts.factor_ == 1.0F && tts.min_transfer_time_ == 0_minutes) {
+    if (tts.factor_ == 1.0F && tts.min_transfer_time_ == 0_minutes &&
+        tts.disposable_time_ == 0_minutes) {
       tts.default_ = true;
     }
 

--- a/include/nigiri/routing/transfer_time_settings.h
+++ b/include/nigiri/routing/transfer_time_settings.h
@@ -7,13 +7,13 @@ namespace nigiri::routing {
 struct transfer_time_settings {
   bool operator==(transfer_time_settings const& o) const {
     return default_ == o.default_ ||
-           std::tie(min_transfer_time_, disposable_time_, factor_) ==
-               std::tie(o.min_transfer_time_, disposable_time_, o.factor_);
+           std::tie(min_transfer_time_, additional_time_, factor_) ==
+               std::tie(o.min_transfer_time_, additional_time_, o.factor_);
   }
 
   bool default_{true};
   duration_t min_transfer_time_{0};
-  duration_t disposable_time_{0};
+  duration_t additional_time_{0};
   float factor_{1.0F};
 };
 
@@ -23,7 +23,7 @@ inline T adjusted_transfer_time(transfer_time_settings const& settings,
   if (settings.default_) {
     return duration;
   } else {
-    return static_cast<T>(settings.disposable_time_.count()) +
+    return static_cast<T>(settings.additional_time_.count()) +
            std::max(
                static_cast<T>(settings.min_transfer_time_.count()),
                static_cast<T>(static_cast<float>(duration) * settings.factor_));
@@ -38,7 +38,7 @@ inline std::chrono::duration<Rep, std::ratio<60>> adjusted_transfer_time(
     return duration;
   } else {
     return std::chrono::duration<Rep, std::ratio<60>>{
-        static_cast<Rep>(settings.disposable_time_.count()) +
+        static_cast<Rep>(settings.additional_time_.count()) +
         std::max(static_cast<Rep>(settings.min_transfer_time_.count()),
                  static_cast<Rep>(static_cast<float>(duration.count()) *
                                   settings.factor_))};

--- a/include/nigiri/routing/transfer_time_settings.h
+++ b/include/nigiri/routing/transfer_time_settings.h
@@ -7,12 +7,13 @@ namespace nigiri::routing {
 struct transfer_time_settings {
   bool operator==(transfer_time_settings const& o) const {
     return default_ == o.default_ ||
-           std::tie(min_transfer_time_, factor_) ==
-               std::tie(o.min_transfer_time_, o.factor_);
+           std::tie(min_transfer_time_, disposable_time_, factor_) ==
+               std::tie(o.min_transfer_time_, disposable_time_, o.factor_);
   }
 
   bool default_{true};
   duration_t min_transfer_time_{0};
+  duration_t disposable_time_{0};
   float factor_{1.0F};
 };
 
@@ -22,9 +23,10 @@ inline T adjusted_transfer_time(transfer_time_settings const& settings,
   if (settings.default_) {
     return duration;
   } else {
-    return std::max(
-        static_cast<T>(settings.min_transfer_time_.count()),
-        static_cast<T>(static_cast<float>(duration) * settings.factor_));
+    return static_cast<T>(settings.disposable_time_.count()) +
+           std::max(
+               static_cast<T>(settings.min_transfer_time_.count()),
+               static_cast<T>(static_cast<float>(duration) * settings.factor_));
   }
 }
 
@@ -36,6 +38,7 @@ inline std::chrono::duration<Rep, std::ratio<60>> adjusted_transfer_time(
     return duration;
   } else {
     return std::chrono::duration<Rep, std::ratio<60>>{
+        static_cast<Rep>(settings.disposable_time_.count()) +
         std::max(static_cast<Rep>(settings.min_transfer_time_.count()),
                  static_cast<Rep>(static_cast<float>(duration.count()) *
                                   settings.factor_))};

--- a/test/routing/transfer_time_settings_test.cc
+++ b/test/routing/transfer_time_settings_test.cc
@@ -216,35 +216,35 @@ TEST(routing, transfer_time_settings_test) {
       EXPECT_EQ(expected_A_C_f20, results_to_str(results, tt));
     }
     {
-      // A -> C, default transfer time, 2 min disposable (= 4 min)
+      // A -> C, default transfer time, 2 min additional (= 4 min)
       auto const results =
           search(tt, nullptr, "A", "C", tt.date_range_, dir,
-                 {.default_ = false, .disposable_time_ = duration_t{2}});
+                 {.default_ = false, .additional_time_ = duration_t{2}});
       EXPECT_EQ(expected_A_C_f20, results_to_str(results, tt));
     }
     {
-      // A -> C, 1.5x transfer time, 1 min disposable (= 4 min)
+      // A -> C, 1.5x transfer time, 1 min additional (= 4 min)
       auto const results = search(tt, nullptr, "A", "C", tt.date_range_, dir,
                                   {.default_ = false,
-                                   .disposable_time_ = duration_t{1},
+                                   .additional_time_ = duration_t{1},
                                    .factor_ = 1.5F});
       EXPECT_EQ(expected_A_C_f20, results_to_str(results, tt));
     }
     {
-      // A -> C, min 3 min transfer time, 1 min disposable (= 4 min)
+      // A -> C, min 3 min transfer time, 1 min additional (= 4 min)
       auto const results = search(tt, nullptr, "A", "C", tt.date_range_, dir,
                                   {.default_ = false,
                                    .min_transfer_time_ = duration_t{3},
-                                   .disposable_time_ = duration_t{1}});
+                                   .additional_time_ = duration_t{1}});
       EXPECT_EQ(expected_A_C_f20, results_to_str(results, tt));
     }
     {
-      // A -> C, min 3 min transfer time, 2.5x transfer time, 5 min disposable
+      // A -> C, min 3 min transfer time, 2.5x transfer time, 5 min additional
       // (= 10 min)
       auto const results = search(tt, nullptr, "A", "C", tt.date_range_, dir,
                                   {.default_ = false,
                                    .min_transfer_time_ = duration_t{3},
-                                   .disposable_time_ = duration_t{5},
+                                   .additional_time_ = duration_t{5},
                                    .factor_ = 2.5F});
       EXPECT_EQ(expected_A_C_min10, results_to_str(results, tt));
     }

--- a/test/routing/transfer_time_settings_test.cc
+++ b/test/routing/transfer_time_settings_test.cc
@@ -215,5 +215,38 @@ TEST(routing, transfer_time_settings_test) {
                                    .factor_ = 2.0F});
       EXPECT_EQ(expected_A_C_f20, results_to_str(results, tt));
     }
+    {
+      // A -> C, default transfer time, 2 min disposable (= 4 min)
+      auto const results =
+          search(tt, nullptr, "A", "C", tt.date_range_, dir,
+                 {.default_ = false, .disposable_time_ = duration_t{2}});
+      EXPECT_EQ(expected_A_C_f20, results_to_str(results, tt));
+    }
+    {
+      // A -> C, 1.5x transfer time, 1 min disposable (= 4 min)
+      auto const results = search(tt, nullptr, "A", "C", tt.date_range_, dir,
+                                  {.default_ = false,
+                                   .disposable_time_ = duration_t{1},
+                                   .factor_ = 1.5F});
+      EXPECT_EQ(expected_A_C_f20, results_to_str(results, tt));
+    }
+    {
+      // A -> C, min 3 min transfer time, 1 min disposable (= 4 min)
+      auto const results = search(tt, nullptr, "A", "C", tt.date_range_, dir,
+                                  {.default_ = false,
+                                   .min_transfer_time_ = duration_t{3},
+                                   .disposable_time_ = duration_t{1}});
+      EXPECT_EQ(expected_A_C_f20, results_to_str(results, tt));
+    }
+    {
+      // A -> C, min 3 min transfer time, 2.5x transfer time, 5 min disposable
+      // (= 10 min)
+      auto const results = search(tt, nullptr, "A", "C", tt.date_range_, dir,
+                                  {.default_ = false,
+                                   .min_transfer_time_ = duration_t{3},
+                                   .disposable_time_ = duration_t{5},
+                                   .factor_ = 2.5F});
+      EXPECT_EQ(expected_A_C_min10, results_to_str(results, tt));
+    }
   }
 }


### PR DESCRIPTION
This adds an option to increase the time between transfers by a fixed duration. This setting can be used, if passengers want some time for orientation or to compensate small delays.