### PR TITLE
Fix loading GTFS frequencies with < 60 seconds headway

### DIFF
--- a/src/loader/gtfs/trip.cc
+++ b/src/loader/gtfs/trip.cc
@@ -382,10 +382,16 @@ void read_frequencies(trip_data& trips, std::string_view file_content) {
            if (!frequencies.has_value()) {
              frequencies = std::vector<frequency>{};
            }
+
+           // If the service operates multiple times per minute, make sure not
+           // to end up with zero.
+           auto headway_minutes = duration_t{std::max(
+               int(std::lround(static_cast<float>(headway_secs) / 60)), 1)};
+
            frequencies->emplace_back(
                frequency{hhmm_to_min(freq.start_time_->view()),
-                         hhmm_to_min(freq.end_time_->view()),
-                         duration_t{headway_secs / 60}, schedule_relationship});
+                         hhmm_to_min(freq.end_time_->view()), headway_minutes,
+                         schedule_relationship});
          });
 }
 

--- a/src/loader/gtfs/trip.cc
+++ b/src/loader/gtfs/trip.cc
@@ -385,9 +385,8 @@ void read_frequencies(trip_data& trips, std::string_view file_content) {
 
            // If the service operates multiple times per minute, make sure not
            // to end up with zero.
-           auto headway_minutes = duration_t{std::max(
-               int(std::lround(static_cast<float>(headway_secs) / 60)), 1)};
-
+           auto const headway_minutes = duration_t{
+               std::max(static_cast<int>(std::round(headway_secs / 60.F)), 1)};
            frequencies->emplace_back(
                frequency{hhmm_to_min(freq.start_time_->view()),
                          hhmm_to_min(freq.end_time_->view()), headway_minutes,

--- a/src/loader/gtfs/trip.cc
+++ b/src/loader/gtfs/trip.cc
@@ -385,8 +385,10 @@ void read_frequencies(trip_data& trips, std::string_view file_content) {
 
            // If the service operates multiple times per minute, make sure not
            // to end up with zero.
-           auto const headway_minutes = duration_t{
-               std::max(static_cast<int>(std::round(headway_secs / 60.F)), 1)};
+           auto const headway_minutes = duration_t{std::max(
+               static_cast<int>(
+                   std::round(static_cast<float>(headway_secs) / 60.F)),
+               1)};
            frequencies->emplace_back(
                frequency{hhmm_to_min(freq.start_time_->view()),
                          hhmm_to_min(freq.end_time_->view()), headway_minutes,


### PR DESCRIPTION
Fixes https://github.com/motis-project/motis/issues/671

The fundamental issue is that the GTFS file specifies a 59 second headway, which will be converted to minute granularity by dividing by 60. The / operator on integers truncates towards zero, so we end up with a 0 headway. 

This then makes `number_of_iterations` divide by zero.

for exact_times != 1, properly rounding should be good enough as long as we don't end up with zero.