### PR TITLE
Via search fixes

### DIFF
--- a/include/nigiri/routing/raptor/raptor.h
+++ b/include/nigiri/routing/raptor/raptor.h
@@ -592,8 +592,8 @@ private:
           if (best_time == kInvalid) {
             return;
           }
-          auto const stay = Vias != 0 && is_via_[Vias - 1][i]
-                                ? via_stops_[Vias - 1].stay_
+          auto const stay = Vias != 0 && is_via_[Vias - 1U][i]
+                                ? via_stops_[Vias - 1U].stay_
                                 : 0_minutes;
           auto const end_time =
               clamp(best_time + stay.count() + dir(dist_to_end_[i]));

--- a/include/nigiri/routing/raptor/raptor.h
+++ b/include/nigiri/routing/raptor/raptor.h
@@ -336,9 +336,9 @@ private:
           continue;
         }
 
-        auto const is_dest = v == Vias && is_dest_[i];
         auto const is_via = v != Vias && is_via_[v][i];
         auto const target_v = is_via ? v + 1 : v;
+        auto const is_dest = target_v == Vias && is_dest_[i];
         auto const stay = is_via ? via_stops_[v].stay_ : 0_minutes;
 
         trace(
@@ -592,7 +592,11 @@ private:
           if (best_time == kInvalid) {
             return;
           }
-          auto const end_time = clamp(best_time + dir(dist_to_end_[i]));
+          auto const stay = Vias != 0 && is_via_[Vias - 1][i]
+                                ? via_stops_[Vias - 1].stay_
+                                : 0_minutes;
+          auto const end_time =
+              clamp(best_time + stay.count() + dir(dist_to_end_[i]));
 
           if (is_better(end_time, best_[kIntermodalTarget][Vias])) {
             round_times_[k][kIntermodalTarget][Vias] = end_time;
@@ -662,9 +666,17 @@ private:
           auto const v = Vias - j;
           auto target_v = v + v_offset[v];
           if (et[v] && stp.can_finish<SearchDir>(is_wheelchair_)) {
-            auto const is_via = target_v != Vias && is_via_[target_v][l_idx] &&
-                                via_stops_[target_v].stay_ == 0_minutes;
-            if (is_via) {
+            auto const is_via = target_v != Vias && is_via_[target_v][l_idx];
+            auto const is_no_stay_via =
+                is_via && via_stops_[target_v].stay_ == 0_minutes;
+
+            // special case: stop is via with stay > 0m + destination
+            auto const is_via_and_dest =
+                is_via && !is_no_stay_via &&
+                (is_dest_[l_idx] ||
+                 (is_intermodal_dest() && state_.end_reachable_[l_idx]));
+
+            if (is_no_stay_via) {
               ++v_offset[v];
               ++target_v;
             }
@@ -700,6 +712,36 @@ private:
               state_.station_mark_.set(l_idx, true);
               current_best = by_transport;
               any_marked = true;
+            }
+
+            if (is_via_and_dest) {
+              auto const dest_v = target_v + 1;
+              assert(dest_v == Vias);
+              auto const best_dest =
+                  get_best(round_times_[k - 1][l_idx][dest_v],
+                           tmp_[l_idx][dest_v], best_[l_idx][dest_v]);
+
+              if (is_better(by_transport, best_dest) &&
+                  is_better(by_transport, time_at_dest_[k]) &&
+                  lb_[l_idx] != kUnreachable &&
+                  is_better(by_transport + dir(lb_[l_idx]), time_at_dest_[k])) {
+                trace_upd(
+                    "┊ │k={} v={}->{}   RT name={}, dbg={}, "
+                    "time_by_transport={}, "
+                    "BETTER THAN dest_best={} => update, {} marking station "
+                    "{} (destination)!\n",
+                    k, v, dest_v, tt_.transport_name(et[v].t_idx_),
+                    tt_.dbg(et[v].t_idx_), to_unix(by_transport),
+                    to_unix(best_dest),
+                    !is_better(by_transport, best_dest) ? "NOT" : "",
+                    location{tt_, stp.location_idx()});
+
+                ++stats_.n_earliest_arrival_updated_by_route_;
+                tmp_[l_idx][dest_v] =
+                    get_best(by_transport, tmp_[l_idx][dest_v]);
+                state_.station_mark_.set(l_idx, true);
+                any_marked = true;
+              }
             }
           }
         }
@@ -783,19 +825,27 @@ private:
           auto const by_transport = time_at_stop(
               r, et[v], stop_idx, kFwd ? event_type::kArr : event_type::kDep);
 
-          auto const is_via = target_v != Vias && is_via_[target_v][l_idx] &&
-                              via_stops_[target_v].stay_ == 0_minutes;
+          auto const is_via = target_v != Vias && is_via_[target_v][l_idx];
+          auto const is_no_stay_via =
+              is_via && via_stops_[target_v].stay_ == 0_minutes;
+
+          // special case: stop is via with stay > 0m + destination
+          auto const is_via_and_dest =
+              is_via && !is_no_stay_via &&
+              (is_dest_[l_idx] ||
+               (is_intermodal_dest() && state_.end_reachable_[l_idx]));
 
           if (Vias != 0) {
             trace_upd(
                 "┊ │k={} v={}(+{})={} via_count={} is_via_dest={} stay={} "
-                "is_via={}\n",
+                "is_via={} is_dest={} is_via_and_dest={}\n",
                 k, v, v_offset[v], target_v, Vias,
                 target_v != Vias ? is_via_[target_v][l_idx] : is_dest_[l_idx],
-                via_stops_[target_v].stay_, is_via);
+                via_stops_[target_v].stay_, is_no_stay_via, is_dest_[l_idx],
+                is_via_and_dest);
           }
 
-          if (is_via) {
+          if (is_no_stay_via) {
             ++v_offset[v];
             ++target_v;
           }
@@ -863,6 +913,34 @@ private:
                 to_unix(time_at_dest_[k]),
                 is_better(clamp(by_transport + dir(lb_[l_idx])),
                           time_at_dest_[k]));
+          }
+
+          if (is_via_and_dest) {
+            auto const dest_v = target_v + 1;
+            assert(dest_v == Vias);
+            auto const best_dest =
+                get_best(round_times_[k - 1][l_idx][dest_v],
+                         tmp_[l_idx][dest_v], best_[l_idx][dest_v]);
+
+            if (is_better(by_transport, best_dest) &&
+                is_better(by_transport, time_at_dest_[k]) &&
+                lb_[l_idx] != kUnreachable &&
+                is_better(by_transport + dir(lb_[l_idx]), time_at_dest_[k])) {
+              trace_upd(
+                  "┊ │k={} v={}->{}    name={}, dbg={}, time_by_transport={}, "
+                  "BETTER THAN dest_best={} => update, {} marking station "
+                  "{} (destination)!\n",
+                  k, v, dest_v, tt_.transport_name(et[v].t_idx_),
+                  tt_.dbg(et[v].t_idx_), to_unix(by_transport),
+                  to_unix(best_dest),
+                  !is_better(by_transport, best_dest) ? "NOT" : "",
+                  location{tt_, stp.location_idx()});
+
+              ++stats_.n_earliest_arrival_updated_by_route_;
+              tmp_[l_idx][dest_v] = get_best(by_transport, tmp_[l_idx][dest_v]);
+              state_.station_mark_.set(l_idx, true);
+              any_marked = true;
+            }
           }
         } else {
           trace(

--- a/src/routing/raptor/reconstruct.cc
+++ b/src/routing/raptor/reconstruct.cc
@@ -396,15 +396,22 @@ void reconstruct_journey_with_vias(timetable const& tt,
 
     auto const backup_v = v;
 
+    auto const is_final_leg = k == j.transfers_ + 1;
+    auto const is_intermodal =
+        q.dest_match_mode_ == location_match_mode::kIntermodal;
     auto stay_l = 0_minutes;
     auto stay_fp_target = 0_minutes;
-    trace_reconstruct("  [check_fp] v={}, l={}, fp.target={}\n", v,
-                      location{tt, l}, location{tt, fp.target()});
+    trace_reconstruct(
+        "  [check_fp] v={}, l={}, fp.target={}, final_leg={}, intermodal={}\n",
+        v, location{tt, l}, location{tt, fp.target()}, is_final_leg,
+        is_intermodal);
     if (v != 0 && matches(tt, location_match_mode::kEquivalent,
                           q.via_stops_[v - 1].location_, l)) {
       --v;
       if (matches(tt, location_match_mode::kEquivalent, l, fp.target())) {
-        stay_fp_target = q.via_stops_[v].stay_;
+        if (!is_final_leg) {
+          stay_fp_target = q.via_stops_[v].stay_;
+        }
         trace_reconstruct(
             "  [check_fp]: fp start+target matches current via: v={}->{}, "
             "stay_target={}\n",
@@ -420,7 +427,9 @@ void reconstruct_journey_with_vias(timetable const& tt,
                           q.via_stops_[v - 1].location_, fp.target())) {
       --v;
       assert(stay_fp_target == 0_minutes);
-      stay_fp_target = q.via_stops_[v].stay_;
+      if (!is_final_leg || is_intermodal) {
+        stay_fp_target = q.via_stops_[v].stay_;
+      }
       trace_reconstruct(
           "  [check_fp]: fp target matches current via: v={}->{}, "
           "stay_fp_target={}\n",

--- a/src/routing/raptor/reconstruct.cc
+++ b/src/routing/raptor/reconstruct.cc
@@ -396,7 +396,7 @@ void reconstruct_journey_with_vias(timetable const& tt,
 
     auto const backup_v = v;
 
-    auto const is_final_leg = k == j.transfers_ + 1;
+    auto const is_final_leg = k == j.transfers_ + 1U;
     auto const is_intermodal =
         q.dest_match_mode_ == location_match_mode::kIntermodal;
     auto stay_l = 0_minutes;

--- a/src/routing/raptor/reconstruct.cc
+++ b/src/routing/raptor/reconstruct.cc
@@ -182,19 +182,29 @@ void reconstruct_journey_with_vias(timetable const& tt,
         break;
       }
 
+      auto const stop_matches_via =
+          new_v != 0 && q.via_stops_[new_v - 1].stay_ == 0_minutes &&
+          matches(tt, location_match_mode::kEquivalent,
+                  q.via_stops_[new_v - 1].location_, l);
+
+      auto const check_via = [&]() {
+        if (stop_matches_via) {
+          trace_reconstruct(
+              "  [find_entry_in_prev_round] new_v={}->{} (stop matches via)\n",
+              v, new_v, new_v - 1);
+          --new_v;
+        }
+      };
+
       if ((kFwd && !stp.in_allowed(is_wheelchair)) ||
           (!kFwd && !stp.out_allowed(is_wheelchair))) {
+        check_via();
         continue;
       }
 
       auto const event_time = unix_to_delta(
           base, stp.time(kFwd ? event_type::kDep : event_type::kArr));
       auto const round_time = round_times[k - 1][to_idx(l)][new_v];
-
-      auto const stop_matches_via =
-          new_v != 0 && q.via_stops_[new_v - 1].stay_ == 0_minutes &&
-          matches(tt, location_match_mode::kEquivalent,
-                  q.via_stops_[new_v - 1].location_, l);
 
       if (is_better_or_eq(round_time, event_time) ||
           // special case: first stop with meta stations
@@ -212,12 +222,7 @@ void reconstruct_journey_with_vias(timetable const& tt,
             journey::run_enter_exit{r, stop_idx, from_stop_idx}};
       } else {
         trace_rc_transport_entry_not_possible;
-        if (stop_matches_via) {
-          trace_reconstruct(
-              "  [find_entry_in_prev_round] new_v={}->{} (stop matches via)\n",
-              v, new_v, new_v - 1);
-          --new_v;
-        }
+        check_via();
       }
     }
 


### PR DESCRIPTION
Fixes the following bugs in the via search implementation that caused reconstruction errors:

- If a trip passing a via stop has in/out allowed = false at the via stop, reconstructing the journey failed.
- Queries where the last via stop is also a destination and has a non-zero stay duration were not handled properly. They are now handled as follows:
  - Intermodal destination (probably the only useful case): Stay duration at the last stop is added as waiting time between the arrival + start of the intermodal footpath. Transfer time at the last stop is ignored.
  - Station destination: Stay duration at the last stop is ignored (i.e. same result as if stay = 0 in the query). The stay duration can't be properly represented in the output journey in this case, but this doesn't seem like a useful case anyway.