### PR TITLE
time-travel-robustness at beginning of trips

### DIFF
--- a/test/rt/gtfsrt_relative_test.cc
+++ b/test/rt/gtfsrt_relative_test.cc
@@ -1,0 +1,143 @@
+#include "gtest/gtest.h"
+
+#include "google/protobuf/util/json_util.h"
+
+#include "nigiri/loader/gtfs/files.h"
+#include "nigiri/loader/gtfs/load_timetable.h"
+#include "nigiri/loader/init_finish.h"
+#include "nigiri/rt/create_rt_timetable.h"
+#include "nigiri/rt/frun.h"
+#include "nigiri/rt/gtfsrt_resolve_run.h"
+#include "nigiri/rt/gtfsrt_update.h"
+#include "nigiri/rt/util.h"
+#include "nigiri/timetable.h"
+
+#include "./util.h"
+
+using namespace nigiri;
+using namespace nigiri::loader;
+using namespace nigiri::loader::gtfs;
+using namespace nigiri::rt;
+using namespace date;
+using namespace std::chrono_literals;
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+
+namespace {
+
+mem_dir test_files() {
+  return mem_dir::read(R"(
+     "(
+# agency.txt
+agency_name,agency_url,agency_timezone,agency_lang,agency_phone,agency_id
+test,https://test.com,Europe/Berlin,DE,0800123456,AGENCY_1
+
+# stops.txt
+stop_id,stop_name,stop_lat,stop_lon
+A,A,1.0,1.0
+B,B,2.0,2.0
+C,C,3.0,3.0
+D,D,4.0,4.0
+E,E,5.0,5.0
+F,F,6.0,6.0
+
+# calendar_dates.txt
+service_id,date,exception_type
+SERVICE_1,20231126,1
+
+# routes.txt
+route_id,agency_id,route_short_name,route_long_name,route_type
+ROUTE_1,AGENCY_1,Route 1,,3
+
+# trips.txt
+route_id,service_id,trip_id,trip_headsign,block_id,
+ROUTE_1,SERVICE_1,TRIP_1,E,,
+
+# stop_times.txt
+trip_id,arrival_time,departure_time,stop_id,stop_sequence,pickup_type,drop_off_type
+TRIP_1,10:00:00,10:00:00,A,1,0,0
+TRIP_1,11:00:00,11:00:00,B,2,0,0
+TRIP_1,12:00:00,12:00:00,C,3,0,0
+TRIP_1,13:00:00,13:00:00,D,4,0,0
+TRIP_1,14:00:00,14:00:00,E,5,0,0
+TRIP_1,15:00:00,15:00:00,F,6,0,0
+)");
+}
+
+auto const kTripUpdate =
+    R"({
+ "header": {
+  "gtfsRealtimeVersion": "2.0",
+  "incrementality": "FULL_DATASET",
+  "timestamp": "1691660324"
+ },
+ "entity": [
+  {
+    "id": "3248651",
+    "isDeleted": false,
+    "tripUpdate": {
+     "trip": {
+      "tripId": "TRIP_1",
+      "startTime": "10:00:00",
+      "startDate": "20231126"
+     },
+     "stopTimeUpdate": [
+        {
+          "stop_sequence":3,
+          "arrival":{"delay":-5400},
+          "departure":{"delay":-5400},
+          "schedule_relationship":"SCHEDULED"
+        },
+        {
+          "stop_sequence":5,
+          "arrival":{"delay":-5460},
+          "departure":{"delay":-5520},
+          "schedule_relationship":"SCHEDULED"
+        }
+      ]
+    }
+  }
+ ]
+})"s;
+
+constexpr auto const expected = R"(
+   0: A       A...............................................                                                             d: 26.11 09:00 [26.11 10:00]  RT 26.11 09:00 [26.11 10:00]  [{name=Bus Route 1, day=2023-11-26, id=TRIP_1, src=0}]
+   1: B       B............................................... a: 26.11 10:00 [26.11 11:00]  RT 26.11 10:00 [26.11 11:00]  d: 26.11 10:00 [26.11 11:00]  RT 26.11 10:00 [26.11 11:00]  [{name=Bus Route 1, day=2023-11-26, id=TRIP_1, src=0}]
+   2: C       C............................................... a: 26.11 11:00 [26.11 12:00]  RT 26.11 10:00 [26.11 11:00]  d: 26.11 11:00 [26.11 12:00]  RT 26.11 10:00 [26.11 11:00]  [{name=Bus Route 1, day=2023-11-26, id=TRIP_1, src=0}]
+   3: D       D............................................... a: 26.11 12:00 [26.11 13:00]  RT 26.11 10:30 [26.11 11:30]  d: 26.11 12:00 [26.11 13:00]  RT 26.11 10:30 [26.11 11:30]  [{name=Bus Route 1, day=2023-11-26, id=TRIP_1, src=0}]
+   4: E       E............................................... a: 26.11 13:00 [26.11 14:00]  RT 26.11 11:29 [26.11 12:29]  d: 26.11 13:00 [26.11 14:00]  RT 26.11 11:29 [26.11 12:29]  [{name=Bus Route 1, day=2023-11-26, id=TRIP_1, src=0}]
+   5: F       F............................................... a: 26.11 14:00 [26.11 15:00]  RT 26.11 12:28 [26.11 13:28]
+)"sv;
+
+}  // namespace
+
+TEST(rt, gtfs_rt_relative) {
+  // Load static timetable.
+  timetable tt;
+  register_special_stations(tt);
+  tt.date_range_ = {date::sys_days{2023_y / November / 25},
+                    date::sys_days{2023_y / November / 27}};
+  load_timetable({}, source_idx_t{0}, test_files(), tt);
+  finalize(tt);
+
+  // Create empty RT timetable.
+  auto rtt =
+      rt::create_rt_timetable(tt, date::sys_days{2023_y / November / 26});
+
+  // Update.
+  auto const msg = rt::json_to_protobuf(kTripUpdate);
+  gtfsrt_update_buf(tt, rtt, source_idx_t{0}, "", msg);
+
+  // Print trip.
+  transit_realtime::TripDescriptor td;
+  td.set_start_date("20231126");
+  td.set_trip_id("TRIP_1");
+  td.set_start_time("10:00:00");
+  auto const [r, t] = rt::gtfsrt_resolve_run(
+      date::sys_days{2023_y / November / 26}, tt, &rtt, source_idx_t{0}, td);
+  ASSERT_TRUE(r.valid());
+
+  auto ss = std::stringstream{};
+  ss << "\n" << rt::frun{tt, &rtt, r};
+  EXPECT_EQ(expected, ss.str());
+}

--- a/test/rt/gtfsrt_rt_test.cc
+++ b/test/rt/gtfsrt_rt_test.cc
@@ -273,7 +273,7 @@ auto const kTripUpdate =
         "time": "1691661152"
        },
        "departure": {
-        "time": "1691661152"
+        "time": "0"
        },
        "stopId": "2524",
        "scheduleRelationship": "SCHEDULED"


### PR DESCRIPTION
As discussed previously in the Transitous channel, time travel is not fixed by nigiri under certain circumstances, e.g. [in this DELFI RT feed update from today 18:06](https://stc.traines.eu/mirror/german-delfi-gtfs-rt/2025-01-01/2025-01-01T18%3A06%3A03%2B01%3A00.gtfs-rt.pbf) ([archive](https://mirror.traines.eu/german-delfi-gtfs-rt/2025-01-01.tar.bz2)) for `trip_id` 2716892734:

```
{
"id":"2716892734",
"trip_update":{"trip":{"trip_id":"2716892734","start_time":"22:11:00","start_date":"20250101","schedule_relationship":0,"route_id":"de:aac:05334|51:aseag_3"},
"stop_time_update":[
{"stop_sequence":2,"arrival":{"delay":-15887},"departure":{"delay":-15887},"stop_id":"de:05334:1177:1:1","schedule_relationship":0},
{"stop_sequence":5,"arrival":{"delay":-15917},"departure":{"delay":-15917},"stop_id":"de:05334:1173:1:1","schedule_relationship":0},
... ]
}
```

I.e. the `stop_time_update`s only start at `stop_sequence` 2, and so nigiri keeps the scheduled times or whatever was set before as rt times for the first two stops, crucially without then ensuring a non-negative travel time to the third stop. This is fixed with this PR.

Note that according to the [GTFS-RT spec](https://gtfs.org/documentation/realtime/feed-entities/trip-updates/), if initial stops don't have a `stop_time_update`, "then the consumer should assume that no real-time information exists for [that stop] at that time, and schedule data from GTFS should be used". AFAICT, the nigiri model does not allow for that, because realtime info can not be removed on a stop-by-stop basis. But I don't think this is a major problem, keeping previous realtime info might actually be helpful in some cases, and this should _in theory_ only occur for stops in the past...