### PR TITLE
Remove unavailable/unused cmake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,12 +87,6 @@ target_link_libraries(nigiri PUBLIC cista geo utl fmt date miniz date-tz wyhash 
 target_compile_features(nigiri PUBLIC cxx_std_23)
 target_compile_options(nigiri PRIVATE ${nigiri-compile-options})
 
-# --- MAIN ---
-file(GLOB_RECURSE nigiri-server-files server/main.cc)
-add_executable(nigiri-server ${nigiri-server-files})
-target_link_libraries(nigiri-server PRIVATE nigiri)
-target_compile_features(nigiri-server PUBLIC cxx_std_23)
-
 # --- IMPORTER ---
 file(GLOB_RECURSE nigiri-import-files exe/import.cc)
 add_executable(nigiri-import ${nigiri-import-files})


### PR DESCRIPTION
As the `main.cc` file targeted here has been removed/refactored to be part of some other target, this lets the build fail, if no target is specified and can be removed