### PR TITLE
Make One-to-All template parameter a regular parameter

### DIFF
--- a/include/nigiri/routing/one_to_all.h
+++ b/include/nigiri/routing/one_to_all.h
@@ -24,9 +24,9 @@ raptor_state one_to_all(timetable const& tt,
                         rt_timetable const* rtt,
                         query const& q);
 
-template <direction SearchDir>
 fastest_offset get_fastest_one_to_all_offsets(timetable const& tt,
                                               raptor_state const& state,
+                                              direction,
                                               location_idx_t,
                                               unixtime_t start_time,
                                               std::uint8_t transfers);

--- a/src/routing/one_to_all.cc
+++ b/src/routing/one_to_all.cc
@@ -102,16 +102,19 @@ raptor_state one_to_all(timetable const& tt,
   }
 }
 
-template <direction SearchDir>
 fastest_offset get_fastest_one_to_all_offsets(timetable const& tt,
                                               raptor_state const& state,
+                                              direction const search_dir,
                                               location_idx_t const l,
                                               unixtime_t const start_time,
                                               std::uint8_t const transfers) {
+  auto const invalid_delta = search_dir == direction::kForward
+                                 ? kInvalidDelta<direction::kForward>
+                                 : kInvalidDelta<direction::kBackward>;
   auto const& round_times = state.get_round_times<kVias>();
   for (auto const k : std::views::iota(std::uint8_t{0U}, transfers + 1U)  //
                           | std::views::reverse) {
-    if (round_times[k][to_idx(l)][kVias] != kInvalidDelta<SearchDir>) {
+    if (round_times[k][to_idx(l)][kVias] != invalid_delta) {
       auto const base =
           tt.internal_interval_days().from_ +
           static_cast<int>(to_idx(make_base(tt, start_time))) * date::days{1};
@@ -131,17 +134,5 @@ template raptor_state one_to_all<direction::kForward>(timetable const&,
 template raptor_state one_to_all<direction::kBackward>(timetable const&,
                                                        rt_timetable const*,
                                                        query const&);
-template fastest_offset get_fastest_one_to_all_offsets<direction::kForward>(
-    timetable const&,
-    raptor_state const&,
-    location_idx_t const,
-    unixtime_t const,
-    std::uint8_t const);
-template fastest_offset get_fastest_one_to_all_offsets<direction::kBackward>(
-    timetable const&,
-    raptor_state const&,
-    location_idx_t const,
-    unixtime_t const,
-    std::uint8_t const);
 
 }  // namespace nigiri::routing

--- a/test/rt/frun_shape_test.cc
+++ b/test/rt/frun_shape_test.cc
@@ -880,16 +880,18 @@ TEST(
 
       // Test duration and number of transfers
       {
-        auto const stats_s = get_fastest_one_to_all_offsets<kSearchDir>(
-            tt, state, to_location_idx("S"), start_time, q.max_transfers_);
+        auto const stats_s = get_fastest_one_to_all_offsets(
+            tt, state, kSearchDir, to_location_idx("S"), start_time,
+            q.max_transfers_);
         ASSERT_EQ(stats_s.duration_, delta_t{140});
         ASSERT_EQ(stats_s.k_, 2U);
-        auto const stats_w = get_fastest_one_to_all_offsets<kSearchDir>(
-            tt, state, to_location_idx("W"), start_time, q.max_transfers_);
+        auto const stats_w = get_fastest_one_to_all_offsets(
+            tt, state, kSearchDir, to_location_idx("W"), start_time,
+            q.max_transfers_);
         ASSERT_EQ(stats_w.duration_, delta_t{200});
         ASSERT_EQ(stats_w.k_, 2U);
-        auto const stats_s_direct = get_fastest_one_to_all_offsets<kSearchDir>(
-            tt, state, to_location_idx("S"), start_time, 1);
+        auto const stats_s_direct = get_fastest_one_to_all_offsets(
+            tt, state, kSearchDir, to_location_idx("S"), start_time, 1);
         ASSERT_EQ(stats_s_direct.duration_, delta_t{185});
         ASSERT_EQ(stats_s_direct.k_, 1U);
       }
@@ -914,8 +916,9 @@ TEST(
     ASSERT_FALSE(
         is_reachable(state, to_location_idx("A"), kUnreachable));  // 5 hours
 
-    auto const stats_b = get_fastest_one_to_all_offsets<kSearchDir>(
-        tt, state, to_location_idx("B"), start_time, q.max_transfers_);
+    auto const stats_b = get_fastest_one_to_all_offsets(
+        tt, state, kSearchDir, to_location_idx("B"), start_time,
+        q.max_transfers_);
     ASSERT_EQ(stats_b.duration_, delta_t{-150});
   }
 }


### PR DESCRIPTION
Simplifies the One-to-All API, as discussed in motis-project/motis#783.