### PR TITLE
fix floating point exception

### DIFF
--- a/include/nigiri/loader/gtfs/local_to_utc.h
+++ b/include/nigiri/loader/gtfs/local_to_utc.h
@@ -13,6 +13,7 @@
 #include "nigiri/loader/gtfs/trip.h"
 #include "nigiri/common/day_list.h"
 #include "nigiri/common/split_duration.h"
+#include "nigiri/logging.h"
 #include "nigiri/timetable.h"
 
 namespace nigiri::loader::gtfs {
@@ -135,7 +136,10 @@ void expand_local_to_utc(trip_data const& trip_data,
   auto trip_it = begin(fet.trips_);
   auto offsets_it = begin(fet.offsets_);
   while (trip_it != end(fet.trips_)) {
-    if (trip_data.get(*trip_it).event_times_.size() <= 1U) {
+    auto const& t = trip_data.get(*trip_it);
+    if (t.event_times_.size() <= 1U || t.requires_interpolation_) {
+      log(log_lvl::error, "loader.gtfs.trip",
+          R"(trip "{}": invalid event times, skipping)", t.id_);
       trip_it = fet.trips_.erase(trip_it);
       offsets_it = fet.offsets_.erase(offsets_it);
     } else {

--- a/src/loader/gtfs/trip.cc
+++ b/src/loader/gtfs/trip.cc
@@ -133,8 +133,9 @@ void trip::interpolate() {
   struct bound {
     explicit bound(minutes_after_midnight_t t) : min_{t}, max_{t} {}
     minutes_after_midnight_t interpolate(int const idx) const {
+      auto const denom = max_idx_ - min_idx_;
       auto const p =
-          static_cast<double>(idx - min_idx_) / (max_idx_ - min_idx_);
+          denom > 0 ? static_cast<double>(idx - min_idx_) / denom : 0;
       return min_ + duration_t{static_cast<duration_t::rep>(
                         std::round((max_ - min_).count() * p))};
     }
@@ -160,10 +161,12 @@ void trip::interpolate() {
       max_idx = static_cast<unsigned>(&(*it) - &bounds.front()) / 2U;
     }
   }
-  utl::verify(max != kInterpolate, "last arrival cannot be interpolated");
+  utl::verify(bounds.size() > 1 && bounds[bounds.size() - 2].max_idx_ != 0,
+              "last arrival cannot be interpolated");
 
   auto min = duration_t{0};
-  auto min_idx = 0;
+  auto const last = static_cast<int>(event_times_.size() - 1);
+  auto min_idx = last;
   for (auto it = bounds.begin(); it != bounds.end(); ++it) {
     if (it->min_ == kInterpolate) {
       it->min_ = min;
@@ -173,7 +176,8 @@ void trip::interpolate() {
       min_idx = static_cast<unsigned>(&(*it) - &bounds.front()) / 2U;
     }
   }
-  utl::verify(min != kInterpolate, "first arrival cannot be interpolated");
+  utl::verify(bounds[1].min_idx_ != last,
+              "first departure cannot be interpolated");
 
   for (auto const [idx, entry] : utl::enumerate(event_times_)) {
     auto const& arr = bounds[2 * idx];

--- a/test/loader/gtfs/stop_time_test.cc
+++ b/test/loader/gtfs/stop_time_test.cc
@@ -44,6 +44,7 @@ TEST(gtfs, quoted_interpolate) {
   EXPECT_EQ(6h + 35min, ev[1].dep_);
   EXPECT_EQ(6h + 49min, ev[2].arr_);
   EXPECT_EQ(7h, ev[2].dep_);
+  EXPECT_FALSE(trips.data_[gtfs_trip_idx_t{0}].requires_interpolation_);
 }
 
 TEST(gtfs, unquoted_interpolate) {
@@ -76,6 +77,7 @@ L001I01S1FES,08:31:00,08:37:00,23,19,,0,0,7.473
   EXPECT_EQ(8h + 16min, ev[1].dep_);
   EXPECT_EQ(8h + 31min, ev[2].arr_);
   EXPECT_EQ(8h + 37min, ev[2].dep_);
+  EXPECT_FALSE(trips.data_[gtfs_trip_idx_t{0}].requires_interpolation_);
 }
 
 TEST(gtfs, start_end_interpolate) {
@@ -108,6 +110,7 @@ L001I01S1FES,08:31:00,,23,19,,0,0,7.473
   EXPECT_EQ(8h + 16min, ev[1].dep_);
   EXPECT_EQ(8h + 31min, ev[2].arr_);
   EXPECT_EQ(8h + 31min, ev[2].dep_);
+  EXPECT_FALSE(trips.data_[gtfs_trip_idx_t{0}].requires_interpolation_);
 }
 
 TEST(gtfs, failed_first_interpolate) {
@@ -131,7 +134,8 @@ L001I01S1FES,,08:31:00,23,19,,0,0,7.473
   read_stop_times(tt, trips, stops, kStopTimes, true);
 
   EXPECT_TRUE(trips.data_[gtfs_trip_idx_t{0}].requires_interpolation_);
-  EXPECT_THROW(trips.data_[gtfs_trip_idx_t{0}].interpolate(), std::exception);
+  trips.data_[gtfs_trip_idx_t{0}].interpolate();
+  EXPECT_TRUE(trips.data_[gtfs_trip_idx_t{0}].requires_interpolation_);
 }
 
 TEST(gtfs, failed_last_interpolate) {
@@ -155,7 +159,8 @@ L001I01S1FES,,,23,19,,0,0,7.473
   read_stop_times(tt, trips, stops, kStopTimes, true);
 
   EXPECT_TRUE(trips.data_[gtfs_trip_idx_t{0}].requires_interpolation_);
-  EXPECT_THROW(trips.data_[gtfs_trip_idx_t{0}].interpolate(), std::exception);
+  trips.data_[gtfs_trip_idx_t{0}].interpolate();
+  EXPECT_TRUE(trips.data_[gtfs_trip_idx_t{0}].requires_interpolation_);
 }
 
 TEST(gtfs, read_stop_times_example_data) {

--- a/test/rt/gtfsrt_resolve_trip_test.cc
+++ b/test/rt/gtfsrt_resolve_trip_test.cc
@@ -137,6 +137,7 @@ Miami-Dade Transit,27757,1,SO.MIAMI HTS-PERRINE VIA SOUTHLAND,3,FF00FF,FFFFFF,-9
 route_id,trip_id,service_id,trip_headsign,direction_id,block_id,shape_id,drt_advance_book_min,peak_offpeak
 27757,5456914,1,1 - SW 168 St,0,1484970,196385,0.0,0
 27757,5456915,1,1 - SW 168 St,0,1484970,196385,0.0,0
+27757,5456916,1,1 - SW 168 St,0,1484970,196385,0.0,0
 
 # stop_times.txt
 trip_id,stop_id,arrival_time,departure_time,timepoint,stop_sequence,shape_dist_traveled,continuous_pickup,continuous_drop_off,start_service_area_radius,end_service_area_radius,departure_buffer
@@ -146,6 +147,9 @@ trip_id,stop_id,arrival_time,departure_time,timepoint,stop_sequence,shape_dist_t
 5456915,1,47:15:00,47:15:00,1,1,,-999,-999,-999.0,-999.0,0
 5456915,3614,47:15:35,47:15:35,0,2,0.1548,-999,-999,-999.0,-999.0,0
 5456915,3213,47:16:20,47:16:20,0,3,0.354,-999,-999,-999.0,-999.0,0
+5456916,1,,,1,1,,-999,-999,-999.0,-999.0,0
+5456916,3614,,,0,2,0.1548,-999,-999,-999.0,-999.0,0
+5456916,3213,,,0,3,0.354,-999,-999,-999.0,-999.0,0
 
 # calendar_dates.txt
 service_id,date,exception_type
@@ -191,6 +195,16 @@ TEST(rt, resolve_tz) {
     auto const r = gtfsrt_resolve_run(date::sys_days{2023_y / August / 3}, tt,
                                       &rtt, source_idx_t{0U}, td);
     EXPECT_TRUE(r.first.valid());
+  }
+
+  {
+    auto td = transit_realtime::TripDescriptor();
+    td.set_start_date("20230803");
+    td.set_trip_id("5456916");
+
+    auto const r = gtfsrt_resolve_run(date::sys_days{2023_y / August / 3}, tt,
+                                      &rtt, source_idx_t{0U}, td);
+    EXPECT_FALSE(r.first.valid());
   }
 }
 


### PR DESCRIPTION
I stumbled upon "Floating point exception (core dumped)" on import, probably same as [this](https://github.com/motis-project/motis/issues/694#issuecomment-2575660882).

Wasn't able to reproduce again, but I suspect this issue in `trip.cc` could be the cause, since divisions by zero do seem to happen there, e.g. when the first `arrival_time` is undefined, which I think I have seen in the wild before (the `utl::verify`s don't seem to do what they promise). 