### PR TITLE
Car transport

### DIFF
--- a/include/nigiri/loader/gtfs/route_key.h
+++ b/include/nigiri/loader/gtfs/route_key.h
@@ -8,12 +8,14 @@ struct route_key_t {
   clasz clasz_{clasz::kOther};
   stop_seq_t stop_seq_;
   bitvec bikes_allowed_;
+  bitvec cars_allowed_;
 };
 
 struct route_key_ptr_t {
   clasz clasz_{clasz::kOther};
   stop_seq_t const* stop_seq_{nullptr};
   bitvec const* bikes_allowed_{nullptr};
+  bitvec const* cars_allowed_{nullptr};
 };
 
 struct route_key_hash {
@@ -21,20 +23,22 @@ struct route_key_hash {
 
   static cista::hash_t hash(clasz const c,
                             stop_seq_t const& seq,
-                            bitvec const& bikes_allowed) {
+                            bitvec const& bikes_allowed,
+                            bitvec const& cars_allowed) {
     auto h = cista::BASE_HASH;
     h = cista::hash_combine(h, cista::hashing<stop_seq_t>{}(seq));
     h = cista::hash_combine(h, c);
     h = cista::hash_combine(h, cista::hashing<bitvec>{}(bikes_allowed));
+    h = cista::hash_combine(h, cista::hashing<bitvec>{}(cars_allowed));
     return h;
   }
 
   cista::hash_t operator()(route_key_t const& x) const {
-    return hash(x.clasz_, x.stop_seq_, x.bikes_allowed_);
+    return hash(x.clasz_, x.stop_seq_, x.bikes_allowed_, x.cars_allowed_);
   }
 
   cista::hash_t operator()(route_key_ptr_t const& x) const {
-    return hash(x.clasz_, *x.stop_seq_, *x.bikes_allowed_);
+    return hash(x.clasz_, *x.stop_seq_, *x.bikes_allowed_, *x.cars_allowed_);
   }
 };
 
@@ -42,14 +46,15 @@ struct route_key_equals {
   using is_transparent = void;
 
   cista::hash_t operator()(route_key_t const& a, route_key_t const& b) const {
-    return std::tie(a.clasz_, a.stop_seq_, a.bikes_allowed_) ==
-           std::tie(b.clasz_, b.stop_seq_, b.bikes_allowed_);
+    return std::tie(a.clasz_, a.stop_seq_, a.bikes_allowed_, a.cars_allowed_) ==
+           std::tie(b.clasz_, b.stop_seq_, b.bikes_allowed_, b.cars_allowed_);
   }
 
   cista::hash_t operator()(route_key_ptr_t const& a,
                            route_key_t const& b) const {
-    return std::tie(a.clasz_, *a.stop_seq_, *a.bikes_allowed_) ==
-           std::tie(b.clasz_, b.stop_seq_, b.bikes_allowed_);
+    return std::tie(a.clasz_, *a.stop_seq_, *a.bikes_allowed_,
+                    *a.cars_allowed_) ==
+           std::tie(b.clasz_, b.stop_seq_, b.bikes_allowed_, b.cars_allowed_);
   }
 };
 

--- a/include/nigiri/loader/gtfs/trip.h
+++ b/include/nigiri/loader/gtfs/trip.h
@@ -68,7 +68,8 @@ struct trip {
        std::string short_name,
        direction_id_t,
        shape_idx_t,
-       bool bikes_allowed);
+       bool bikes_allowed,
+       bool cars_allowed);
 
   trip(trip&&) = default;
   trip& operator=(trip&&) = default;
@@ -107,6 +108,7 @@ struct trip {
   bool requires_interpolation_{false};
   bool requires_sorting_{false};
   bool bikes_allowed_{false};
+  bool cars_allowed_{false};
   std::uint32_t from_line_{0U}, to_line_{0U};
 
   trip_idx_t trip_idx_{trip_idx_t::invalid()};
@@ -126,13 +128,13 @@ struct trip_data {
   vector_map<gtfs_trip_idx_t, trip> data_;
 };
 
-trip_data read_trips(
-    timetable&,
-    route_map_t const&,
-    traffic_days_t const&,
-    shape_loader_state const&,
-    std::string_view file_content,
-    std::array<bool, kNumClasses> const& bikes_allowed_default);
+trip_data read_trips(timetable&,
+                     route_map_t const&,
+                     traffic_days_t const&,
+                     shape_loader_state const&,
+                     std::string_view file_content,
+                     std::array<bool, kNumClasses> const& bikes_allowed_default,
+                     std::array<bool, kNumClasses> const& cars_allowed_default);
 
 void read_frequencies(trip_data&, std::string_view);
 

--- a/include/nigiri/loader/loader_interface.h
+++ b/include/nigiri/loader/loader_interface.h
@@ -18,6 +18,7 @@ struct loader_config {
   unsigned link_stop_distance_{100U};
   std::string default_tz_;
   std::array<bool, kNumClasses> bikes_allowed_default_{};
+  std::array<bool, kNumClasses> cars_allowed_default_{};
 };
 
 struct loader_interface {

--- a/include/nigiri/routing/query.h
+++ b/include/nigiri/routing/query.h
@@ -87,6 +87,7 @@ struct query {
   profile_idx_t prf_idx_{0};
   clasz_mask_t allowed_claszes_{all_clasz_allowed()};
   bool require_bike_transport_{false};
+  bool require_car_transport_{false};
   transfer_time_settings transfer_time_settings_{};
   std::vector<via_stop> via_stops_{};
   std::optional<duration_t> fastest_direct_{};

--- a/include/nigiri/routing/search.h
+++ b/include/nigiri/routing/search.h
@@ -73,6 +73,7 @@ struct search {
 
   Algo init(clasz_mask_t const allowed_claszes,
             bool const require_bikes_allowed,
+            bool const require_cars_allowed,
             transfer_time_settings& tts,
             algo_state_t& algo_state) {
     auto span = get_otel_tracer()->StartSpan("search::init");
@@ -144,6 +145,7 @@ struct search {
                 .count()},
         allowed_claszes,
         require_bikes_allowed,
+        require_cars_allowed,
         q_.prf_idx_ == 2U,
         tts};
   }
@@ -170,6 +172,7 @@ struct search {
         fastest_direct_{get_fastest_direct(tt_, q_, SearchDir)},
         algo_{init(q_.allowed_claszes_,
                    q_.require_bike_transport_,
+                   q_.require_car_transport_,
                    q_.transfer_time_settings_,
                    algo_state)},
         timeout_(timeout) {

--- a/include/nigiri/rt/frun.h
+++ b/include/nigiri/rt/frun.h
@@ -49,6 +49,7 @@ struct run_stop {
   clasz get_scheduled_clasz(event_type = event_type::kDep) const noexcept;
 
   bool bikes_allowed(event_type = event_type::kDep) const noexcept;
+  bool cars_allowed(event_type = event_type::kDep) const noexcept;
 
   route_color get_route_color(event_type = event_type::kDep) const noexcept;
 

--- a/include/nigiri/rt/rt_timetable.h
+++ b/include/nigiri/rt/rt_timetable.h
@@ -213,8 +213,14 @@ struct rt_timetable {
   // RT transport * 2 + 1 -> bikes along parts of the transport
   bitvec rt_transport_bikes_allowed_;
 
+  // same for cars
+  bitvec rt_transport_cars_allowed_;
+
   // RT transport -> bikes allowed for each section
   vecvec<rt_transport_idx_t, bool> rt_bikes_allowed_per_section_;
+
+  // same for cars
+  vecvec<rt_transport_idx_t, bool> rt_cars_allowed_per_section_;
 
   // Service alerts
   alerts alerts_;

--- a/include/nigiri/timetable.h
+++ b/include/nigiri/timetable.h
@@ -181,7 +181,8 @@ struct timetable {
 
   route_idx_t register_route(basic_string<stop::value_type> const& stop_seq,
                              basic_string<clasz> const& clasz_sections,
-                             bitvec const& bikes_allowed_per_section) {
+                             bitvec const& bikes_allowed_per_section,
+                             bitvec const& cars_allowed_per_section) {
     assert(stop_seq.size() > 1U);
     assert(!clasz_sections.empty());
 
@@ -194,10 +195,10 @@ struct timetable {
     route_section_clasz_.emplace_back(clasz_sections);
     route_clasz_.emplace_back(clasz_sections[0]);
 
-    auto const sections = bikes_allowed_per_section.size();
+    auto const bike_sections = bikes_allowed_per_section.size();
     auto const sections_with_bikes_allowed = bikes_allowed_per_section.count();
     auto const bikes_allowed_on_all_sections =
-        sections_with_bikes_allowed == sections && sections != 0;
+        sections_with_bikes_allowed == bike_sections && bike_sections != 0;
     auto const bikes_allowed_on_some_sections =
         sections_with_bikes_allowed != 0U;
     route_bikes_allowed_.resize(route_bikes_allowed_.size() + 2U);
@@ -209,6 +210,23 @@ struct timetable {
       auto bucket = route_bikes_allowed_per_section_[route_idx_t{idx}];
       for (auto i = 0U; i < bikes_allowed_per_section.size(); ++i) {
         bucket.push_back(bikes_allowed_per_section[i]);
+      }
+    }
+
+    auto const car_sections = cars_allowed_per_section.size();
+    auto const sections_with_cars_allowed = cars_allowed_per_section.count();
+    auto const cars_allowed_on_all_sections =
+        sections_with_cars_allowed == car_sections && car_sections != 0;
+    auto const cars_allowed_on_some_sections = sections_with_cars_allowed != 0U;
+    route_cars_allowed_.resize(route_cars_allowed_.size() + 2U);
+    route_cars_allowed_.set(idx * 2, cars_allowed_on_all_sections);
+    route_cars_allowed_.set(idx * 2 + 1, cars_allowed_on_some_sections);
+
+    route_cars_allowed_per_section_.resize(idx + 1);
+    if (cars_allowed_on_some_sections && !cars_allowed_on_all_sections) {
+      auto bucket = route_cars_allowed_per_section_[route_idx_t{idx}];
+      for (auto i = 0U; i < cars_allowed_per_section.size(); ++i) {
+        bucket.push_back(cars_allowed_per_section[i]);
       }
     }
 
@@ -474,10 +492,16 @@ struct timetable {
   // Route * 2 + 1 -> bikes along parts of the route
   bitvec route_bikes_allowed_;
 
+  // same for cars
+  bitvec route_cars_allowed_;
+
   // Route -> bikes allowed per section
   // Only set for routes where the entry in route_bikes_allowed_bitvec_
   // is set to "bikes along parts of the route"
   vecvec<route_idx_t, bool> route_bikes_allowed_per_section_;
+
+  // same for cars
+  vecvec<route_idx_t, bool> route_cars_allowed_per_section_;
 
   // Location -> list of routes
   vecvec<location_idx_t, route_idx_t> location_routes_;

--- a/src/clasz.cc
+++ b/src/clasz.cc
@@ -223,9 +223,9 @@ clasz to_clasz(std::string_view s) {
     case cista::hash("METRO"): return clasz::kMetro;
     case cista::hash("SUBWAY"): return clasz::kSubway;
     case cista::hash("TRAM"): return clasz::kTram;
-    case cista::hash("BUS "): return clasz::kBus;
-    case cista::hash("SHIP "): return clasz::kShip;
-    case cista::hash("OTHER "): return clasz::kOther;
+    case cista::hash("BUS"): return clasz::kBus;
+    case cista::hash("SHIP"): return clasz::kShip;
+    case cista::hash("OTHER"): return clasz::kOther;
   }
   throw utl::fail("{} is not a valid clasz", s);
 }

--- a/src/loader/hrd/service/service_builder.cc
+++ b/src/loader/hrd/service/service_builder.cc
@@ -68,11 +68,12 @@ void service_builder::write_services(source_idx_t const src) {
 
   auto const timer = scoped_timer{"loader.hrd.services.write"};
   auto const empty_bikes_allowed = bitvec{};  // not implemented for hrd
+  auto const empty_cars_allowed = bitvec{};  // not implemented for hrd
   for (auto const& [key, sub_routes] : route_services_) {
     for (auto const& services : sub_routes) {
       auto const& [stop_seq, sections_clasz] = key;
-      auto const route_idx =
-          tt_.register_route(stop_seq, sections_clasz, empty_bikes_allowed);
+      auto const route_idx = tt_.register_route(
+          stop_seq, sections_clasz, empty_bikes_allowed, empty_cars_allowed);
 
       for (auto const& s : stop_seq) {
         auto s_routes = location_routes_[stop{s}.location_idx()];

--- a/src/routing/one_to_all.cc
+++ b/src/routing/one_to_all.cc
@@ -83,6 +83,7 @@ raptor_state one_to_all(timetable const& tt,
       base,
       q.allowed_claszes_,
       q.require_bike_transport_,
+      q.require_car_transport_,
       is_wheelchair,
       q.transfer_time_settings_};
 

--- a/src/rt/frun.cc
+++ b/src/rt/frun.cc
@@ -231,6 +231,20 @@ bool run_stop::bikes_allowed(event_type const ev_type) const noexcept {
   }
 }
 
+bool run_stop::cars_allowed(event_type const ev_type) const noexcept {
+  if (fr_->is_rt() && rtt() != nullptr) {
+    auto const cars_allowed_seq =
+        rtt()->rt_cars_allowed_per_section_.at(fr_->rt_);
+    return cars_allowed_seq.at(
+        cars_allowed_seq.size() == 1U ? 0U : section_idx(ev_type));
+  } else {
+    auto const cars_allowed_seq = tt().route_cars_allowed_per_section_.at(
+        tt().transport_route_.at(fr_->t_.t_idx_));
+    return cars_allowed_seq.at(
+        cars_allowed_seq.size() == 1U ? 0U : section_idx(ev_type));
+  }
+}
+
 route_color run_stop::get_route_color(event_type ev_type) const noexcept {
   if (!fr_->is_scheduled()) {
     return route_color{};

--- a/src/rt/rt_timetable.cc
+++ b/src/rt/rt_timetable.cc
@@ -76,10 +76,12 @@ rt_transport_idx_t rt_timetable::add_rt_transport(
   }
 
   auto const bikes_allowed_default = false;  // TODO
+  auto const cars_allowed_default = false;  // TODO
 
   rt_transport_line_.add_back_sized(0U);
   rt_transport_is_cancelled_.resize(rt_transport_is_cancelled_.size() + 1U);
   rt_transport_bikes_allowed_.resize(rt_transport_bikes_allowed_.size() + 2U);
+  rt_transport_cars_allowed_.resize(rt_transport_bikes_allowed_.size() + 2U);
   rt_transport_section_directions_.add_back_sized(0U);  // TODO outside
   if (!display_name.empty()) {
     rt_transport_display_names_.emplace_back(display_name);
@@ -97,23 +99,35 @@ rt_transport_idx_t rt_timetable::add_rt_transport(
                                     tt.route_bikes_allowed_[r.v_ * 2]);
     rt_transport_bikes_allowed_.set(rt_t_idx * 2 + 1,
                                     tt.route_bikes_allowed_[r.v_ * 2 + 1]);
+    rt_transport_cars_allowed_.set(rt_t_idx * 2,
+                                   tt.route_cars_allowed_[r.v_ * 2]);
+    rt_transport_cars_allowed_.set(rt_t_idx * 2 + 1,
+                                   tt.route_cars_allowed_[r.v_ * 2 + 1]);
   } else if (fallback_r != route_id_idx_t::invalid()) {
     rt_transport_section_clasz_.emplace_back(
         std::vector<clasz>{loader::gtfs::to_clasz(
             tt.route_ids_[src].route_id_type_.at(fallback_r).v_)});  // TODO
     rt_transport_bikes_allowed_.set(rt_t_idx * 2, bikes_allowed_default);
     rt_transport_bikes_allowed_.set(rt_t_idx * 2 + 1, false);
+    rt_transport_cars_allowed_.set(rt_t_idx * 2, cars_allowed_default);
+    rt_transport_cars_allowed_.set(rt_t_idx * 2 + 1, false);
   } else {
     rt_transport_section_clasz_.emplace_back(std::vector<clasz>{clasz::kOther});
     rt_transport_bikes_allowed_.set(rt_t_idx * 2, bikes_allowed_default);
     rt_transport_bikes_allowed_.set(rt_t_idx * 2 + 1, false);
+    rt_transport_cars_allowed_.set(rt_t_idx * 2, cars_allowed_default);
+    rt_transport_cars_allowed_.set(rt_t_idx * 2 + 1, false);
   }
   if (r != route_idx_t::invalid() && stop_seq.empty()) {
     rt_bikes_allowed_per_section_.emplace_back(
         tt.route_bikes_allowed_per_section_[r]);
+    rt_cars_allowed_per_section_.emplace_back(
+        tt.route_cars_allowed_per_section_[r]);
   } else {
     rt_bikes_allowed_per_section_.emplace_back(
         std::vector<bool>{bikes_allowed_default});
+    rt_cars_allowed_per_section_.emplace_back(
+        std::vector<bool>{cars_allowed_default});
   }
 
   assert(time_seq.empty() || time_seq.size() == location_seq.size() * 2U - 2U);

--- a/test/loader/gtfs/stop_time_test.cc
+++ b/test/loader/gtfs/stop_time_test.cc
@@ -183,7 +183,7 @@ TEST(gtfs, read_stop_times_example_data) {
       merge_traffic_days(tt.internal_interval_days(), calendar, dates);
   auto trip_data =
       read_trips(tt, routes, services, {}, files.get_file(kTripsFile).data(),
-                 config.bikes_allowed_default_);
+                 config.bikes_allowed_default_, config.cars_allowed_default_);
   auto const stops = read_stops(source_idx_t{0}, tt, timezones,
                                 files.get_file(kStopFile).data(),
                                 files.get_file(kTransfersFile).data(), 0U);

--- a/test/loader/gtfs/stop_time_test.cc
+++ b/test/loader/gtfs/stop_time_test.cc
@@ -26,7 +26,7 @@ TEST(gtfs, quoted_interpolate) {
   trips.trips_.emplace("101255-L001I01S1LAB", gtfs_trip_idx_t{0U});
   trips.data_.emplace_back(
       nullptr, nullptr, nullptr, "101255-L001I01S1FES", trip_direction_idx_t{},
-      "", direction_id_t::invalid(), shape_idx_t::invalid(), false);
+      "", direction_id_t::invalid(), shape_idx_t::invalid(), false, false);
   auto tt = timetable{};
   auto stops = locations_map{};
   stops.emplace("101255-6", location_idx_t{0});
@@ -59,7 +59,7 @@ L001I01S1FES,08:31:00,08:37:00,23,19,,0,0,7.473
   trips.trips_.emplace("L001I01S1FES", gtfs_trip_idx_t{0U});
   trips.data_.emplace_back(
       nullptr, nullptr, nullptr, "L001I01S1FES", trip_direction_idx_t{}, "",
-      direction_id_t::invalid(), shape_idx_t::invalid(), false);
+      direction_id_t::invalid(), shape_idx_t::invalid(), false, false);
   auto tt = timetable{};
   auto stops = locations_map{};
   stops.emplace("6", location_idx_t{0});
@@ -92,7 +92,7 @@ L001I01S1FES,08:31:00,,23,19,,0,0,7.473
   trips.trips_.emplace("L001I01S1FES", gtfs_trip_idx_t{0U});
   trips.data_.emplace_back(
       nullptr, nullptr, nullptr, "L001I01S1FES", trip_direction_idx_t{}, "",
-      direction_id_t::invalid(), shape_idx_t::invalid(), false);
+      direction_id_t::invalid(), shape_idx_t::invalid(), false, false);
   auto tt = timetable{};
   auto stops = locations_map{};
   stops.emplace("6", location_idx_t{0});
@@ -125,7 +125,7 @@ L001I01S1FES,,08:31:00,23,19,,0,0,7.473
   trips.trips_.emplace("L001I01S1FES", gtfs_trip_idx_t{0U});
   trips.data_.emplace_back(
       nullptr, nullptr, nullptr, "L001I01S1FES", trip_direction_idx_t{}, "",
-      direction_id_t::invalid(), shape_idx_t::invalid(), false);
+      direction_id_t::invalid(), shape_idx_t::invalid(), false, false);
   auto tt = timetable{};
   auto stops = locations_map{};
   stops.emplace("6", location_idx_t{0});
@@ -150,7 +150,7 @@ L001I01S1FES,,,23,19,,0,0,7.473
   trips.trips_.emplace("L001I01S1FES", gtfs_trip_idx_t{0U});
   trips.data_.emplace_back(
       nullptr, nullptr, nullptr, "L001I01S1FES", trip_direction_idx_t{}, "",
-      direction_id_t::invalid(), shape_idx_t::invalid(), false);
+      direction_id_t::invalid(), shape_idx_t::invalid(), false, false);
   auto tt = timetable{};
   auto stops = locations_map{};
   stops.emplace("6", location_idx_t{0});

--- a/test/loader/gtfs/trip_test.cc
+++ b/test/loader/gtfs/trip_test.cc
@@ -41,9 +41,9 @@ TEST(gtfs, read_trips_example_data) {
       shapes_storage{"example_shapes", cista::mmap::protection::WRITE};
   auto const shapes =
       parse_shapes(files.get_file(kShapesFile).data(), shapes_store);
-  auto const trip_data = read_trips(tt, routes, services, shapes,
-                                    files.get_file(kTripsFile).data(),
-                                    config.bikes_allowed_default_);
+  auto const trip_data = read_trips(
+      tt, routes, services, shapes, files.get_file(kTripsFile).data(),
+      config.bikes_allowed_default_, config.cars_allowed_default_);
 
   EXPECT_EQ(2U, trip_data.data_.size());
   EXPECT_NE(end(trip_data.trips_), trip_data.trips_.find("AWE1"));
@@ -75,9 +75,9 @@ TEST(gtfs, read_trips_berlin_data) {
       shapes_storage{"berlin_shapes", cista::mmap::protection::WRITE};
   auto const shapes =
       parse_shapes(files.get_file(kShapesFile).data(), shapes_store);
-  auto const trip_data = read_trips(tt, routes, services, shapes,
-                                    files.get_file(kTripsFile).data(),
-                                    config.bikes_allowed_default_);
+  auto const trip_data = read_trips(
+      tt, routes, services, shapes, files.get_file(kTripsFile).data(),
+      config.bikes_allowed_default_, config.cars_allowed_default_);
 
   EXPECT_EQ(3U, trip_data.data_.size());
 

--- a/test/raptor_search.cc
+++ b/test/raptor_search.cc
@@ -30,6 +30,7 @@ pareto_set<routing::journey> raptor_search(timetable const& tt,
                                            direction const search_dir,
                                            routing::clasz_mask_t const mask,
                                            bool const require_bikes_allowed,
+                                           bool const require_cars_allowed,
                                            profile_idx_t const profile) {
   auto const src = source_idx_t{0};
   auto q = routing::query{
@@ -41,6 +42,7 @@ pareto_set<routing::journey> raptor_search(timetable const& tt,
       .prf_idx_ = profile,
       .allowed_claszes_ = mask,
       .require_bike_transport_ = require_bikes_allowed,
+      .require_car_transport_ = require_cars_allowed,
       .via_stops_ = {}};
   return raptor_search(tt, rtt, std::move(q), search_dir);
 }
@@ -52,10 +54,11 @@ pareto_set<routing::journey> raptor_search(timetable const& tt,
                                            std::string_view time,
                                            direction const search_dir,
                                            routing::clasz_mask_t mask,
-                                           bool const require_bikes_allowed) {
+                                           bool const require_bikes_allowed,
+                                           bool const require_cars_allowed) {
   return raptor_search(tt, rtt, from, to,
                        parse_time_tz(time, "%Y-%m-%d %H:%M %Z"), search_dir,
-                       mask, require_bikes_allowed, 0U);
+                       mask, require_bikes_allowed, require_cars_allowed, 0U);
 }
 
 pareto_set<routing::journey> raptor_search(timetable const& tt,

--- a/test/raptor_search.h
+++ b/test/raptor_search.h
@@ -17,7 +17,8 @@ pareto_set<routing::journey> raptor_search(
     std::string_view time,
     direction = direction::kForward,
     routing::clasz_mask_t mask = routing::all_clasz_allowed(),
-    bool require_bikes_allowed = false);
+    bool require_bikes_allowed = false,
+    bool require_cars_allowed = false);
 
 pareto_set<routing::journey> raptor_search(
     timetable const&,
@@ -28,6 +29,7 @@ pareto_set<routing::journey> raptor_search(
     direction = direction::kForward,
     routing::clasz_mask_t mask = routing::all_clasz_allowed(),
     bool require_bikes_allowed = false,
+    bool require_cars_allowed = false,
     profile_idx_t const profile = 0U);
 
 pareto_set<routing::journey> raptor_search(timetable const&,

--- a/test/routing/wheelchair_assistance_test.cc
+++ b/test/routing/wheelchair_assistance_test.cc
@@ -97,7 +97,7 @@ TEST(routing, wheelchair_assistance) {
 
   auto const results_walk =
       raptor_search(tt, nullptr, "A", "C", iv, direction::kForward,
-                    routing::all_clasz_allowed(), false, 0U);
+                    routing::all_clasz_allowed(), false, false, 0U);
   ASSERT_FALSE(results_walk.begin() == results_walk.end());
   EXPECT_EQ((unixtime_t{sys_days{2024_y / June / 19} + 5_hours}),
             results_walk.begin()->start_time_);
@@ -106,7 +106,7 @@ TEST(routing, wheelchair_assistance) {
 
   auto const results_wheelchair =
       raptor_search(tt, nullptr, "A", "C", iv, direction::kForward,
-                    routing::all_clasz_allowed(), false, 2U);
+                    routing::all_clasz_allowed(), false, false, 2U);
   ASSERT_FALSE(results_wheelchair.begin() == results_wheelchair.end());
   EXPECT_EQ((unixtime_t{sys_days{2024_y / June / 19} + 6_hours}),
             results_wheelchair.begin()->start_time_);


### PR DESCRIPTION
Adds support for traveling with a car (based on #108):
- GTFS: cars_allowed field in trips.txt is now parsed. This is currently not yet in the GTFS standard, but a proposed addition (https://github.com/google/transit/pull/547).
- For trips with cars_allowed = 0 or no car information, a default value based on the route clasz is used (defaults can be specified in loader_config).
- Added a new require_car_transport_ flag to routing::query. If set to false (the default value), returns the same results as before. If set to true, only trips where cars are allowed can be used.