### PR TITLE
Change display_name rules again

### DIFF
--- a/src/loader/gtfs/trip.cc
+++ b/src/loader/gtfs/trip.cc
@@ -203,14 +203,19 @@ void trip::interpolate() {
 }
 
 std::string trip::display_name() const {
-  for (auto const str :
-       {std::string_view{route_->short_name_},
-        std::string_view{route_->long_name_}, std::string_view{short_name_}}) {
-    if (!str.empty()) {
-      return std::string{str};
-    }
+  if (!route_->short_name_.empty() && !short_name_.empty()) {
+    return fmt::format("{} {}", route_->short_name_, short_name_);
   }
-  return {};
+
+  if (!route_->short_name_.empty()) {
+    return route_->short_name_;
+  }
+
+  if (!short_name_.empty()) {
+    return short_name_;
+  }
+
+  return route_->long_name_;
 }
 
 clasz trip::get_clasz(timetable const& tt) const {


### PR DESCRIPTION
Although it looks like just another permutation of what was already tried, this set of rules has the advantage of being able to encode all of the important variants:

- identified by trip name – can be encoded by setting trip_short_name and route_long_name
- identified by route name – can be encoded by setting route_short_name and route_long_name
- identified by both – can be encoded by setting route_short_name and trip_short_name
- none of the above – leave everything else empty and set route_long_name

I found this set of rules by looking at what railways in countries in which trains are only identified by a single trip specific number do in their GTFS. Specifically I looked at:
- HŽPP (official feed)
- The Pieturas feed for Latvia

I think that spec work is still needed to either specify this set of rules or (preferred) add an additional field controlling the display name output, but this allows for short-term improvement.