### PR TITLE
Add support for importing platform_code of stations/stops without a parent

### DIFF
--- a/src/loader/gtfs/stop.cc
+++ b/src/loader/gtfs/stop.cc
@@ -229,10 +229,10 @@ stops_map_t read_stops(source_idx_t const src,
                                    []() { return std::make_unique<stop>(); })
                     .get();
             parent->id_ = new_stop->id_;
+            parent->name_ = new_stop->name_;
             parent->coord_ = new_stop->coord_;
             parent->desc_ = new_stop->desc_;
             parent->timezone_ = new_stop->timezone_;
-            parent->platform_code_ = "";
             parent->children_.emplace(new_stop);
             new_stop->parent_ = parent;
           }

--- a/src/loader/gtfs/stop.cc
+++ b/src/loader/gtfs/stop.cc
@@ -132,7 +132,7 @@ void read_transfers(stop_map_t& stops, std::string_view file_content) {
       |
       utl::for_each([&](csv_transfer const& t) {
         auto const from_stop_it =
-            stops.find(std::make_pair(t.from_stop_id_->view(), false));
+            stops.find(std::pair(t.from_stop_id_->view(), false));
         if (from_stop_it == end(stops)) {
           log(log_lvl::error, "loader.gtfs.transfers", "stop {} not found\n",
               t.from_stop_id_->view());
@@ -140,7 +140,7 @@ void read_transfers(stop_map_t& stops, std::string_view file_content) {
         }
 
         auto const to_stop_it =
-            stops.find(std::make_pair(t.to_stop_id_->view(), false));
+            stops.find(std::pair(t.to_stop_id_->view(), false));
         if (to_stop_it == end(stops)) {
           log(log_lvl::error, "loader.gtfs.transfers", "stop {} not found\n",
               t.to_stop_id_->view());
@@ -196,9 +196,9 @@ stops_map_t read_stops(source_idx_t const src,
       | utl::csv<csv_stop>()  //
       | utl::for_each([&](csv_stop& s) {
           auto const new_stop =
-              utl::get_or_create(stops, std::make_pair(s.id_->view(), false),
-                                 [&]() { return std::make_unique<stop>(); })
-                  .get();
+              utl::get_or_create(stops, std::pair(s.id_->view(), false), [&]() {
+                return std::make_unique<stop>();
+              }).get();
 
           new_stop->id_ = s.id_->view();
           new_stop->name_ = std::move(*s.name_);
@@ -212,8 +212,7 @@ stops_map_t read_stops(source_idx_t const src,
           if (!s.parent_station_->trim().empty()) {
             auto const parent =
                 utl::get_or_create(
-                    stops,
-                    std::make_pair(s.parent_station_->trim().view(), false),
+                    stops, std::pair(s.parent_station_->trim().view(), false),
                     []() { return std::make_unique<stop>(); })
                     .get();
             parent->id_ = s.parent_station_->trim().view();
@@ -225,8 +224,7 @@ stops_map_t read_stops(source_idx_t const src,
             // platform codes, as Motis only supports platform codes in the
             // name attribute of child stops.
             auto const parent =
-                utl::get_or_create(stops,
-                                   std::make_pair(s.id_->trim().view(), true),
+                utl::get_or_create(stops, std::pair(s.id_->trim().view(), true),
                                    []() { return std::make_unique<stop>(); })
                     .get();
             parent->id_ = new_stop->id_;

--- a/src/loader/gtfs/stop.cc
+++ b/src/loader/gtfs/stop.cc
@@ -211,9 +211,10 @@ stops_map_t read_stops(source_idx_t const src,
 
           if (!s.parent_station_->trim().empty()) {
             auto const parent =
-                utl::get_or_create(stops,
-                                   std::make_pair(s.id_->trim().view(), false),
-                                   []() { return std::make_unique<stop>(); })
+                utl::get_or_create(
+                    stops,
+                    std::make_pair(s.parent_station_->trim().view(), false),
+                    []() { return std::make_unique<stop>(); })
                     .get();
             parent->id_ = s.parent_station_->trim().view();
             parent->children_.emplace(new_stop);


### PR DESCRIPTION
This pr adds the ability to import GTFS stops that have a platform_code, but no parent_station. It does this by creating artificial parents which hold the station's name, as motis locations only have name and id but no field for track information. 

stops.txt entries with platform_code but no parent_station is not inline with the GTFS spec, but common practice at least for the Delfi feed. With this pr we strengthen the import to support track data, even if it's a bit out of spec.