### PR TITLE
fix slowDirect for loop lines

### DIFF
--- a/include/nigiri/routing/query.h
+++ b/include/nigiri/routing/query.h
@@ -95,6 +95,7 @@ struct query {
   std::optional<duration_t> fastest_direct_{};
   double fastest_direct_factor_{1.0};
   bool slow_direct_{false};
+  double fastest_slow_direct_factor_{2.0};
 };
 
 }  // namespace nigiri::routing

--- a/src/routing/direct.cc
+++ b/src/routing/direct.cc
@@ -300,7 +300,7 @@ void get_direct(timetable const& tt,
             });
       });
   if (q.fastest_slow_direct_factor_ >= 1.0) {
-    utl::erase_if(direct, [&](journey j) {
+    utl::erase_if(direct, [&](journey const& j) {
       return j.travel_time() >
              shortest_duration * q.fastest_slow_direct_factor_;
     });


### PR DESCRIPTION
or do we need something more sophisticated, because this way, if there is one very fast direct connection, other "relevant" connections at other times will be removed... But the pareto-optimal ones should still be there, so...