### PR TITLE
Fix incorrect traffic days after merge

### DIFF
--- a/src/loader/merge_duplicates.cc
+++ b/src/loader/merge_duplicates.cc
@@ -57,7 +57,7 @@ bool merge(timetable& tt,
   };
 
   auto const is_superset = [](bitfield const& x, bitfield const& y) {
-    return (x & y) == x;
+    return (x & y) == y;
   };
 
   if (is_superset(bf_b, bf_a)) {


### PR DESCRIPTION
This fixes an error, that caused merged trips to contain less traffic days than intended.
Is modification of this test fine? Or does this break something else, that I'm missing right now?