### PR TITLE
Fix log_lvl not updating

### DIFF
--- a/include/nigiri/logging.h
+++ b/include/nigiri/logging.h
@@ -22,7 +22,7 @@ constexpr char const* to_str(log_lvl const lvl) {
   return "";
 }
 
-static log_lvl s_verbosity;
+extern log_lvl s_verbosity;
 
 inline std::string now() {
   using clock = std::chrono::system_clock;

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -2,6 +2,8 @@
 
 namespace nigiri {
 
+log_lvl s_verbosity = log_lvl::debug;
+
 scoped_timer::scoped_timer(std::string name)
     : name_{std::move(name)}, start_{std::chrono::steady_clock::now()} {
   log(log_lvl::info, name_.c_str(), "starting {}", std::string_view{name_});


### PR DESCRIPTION
This changes the scope of `nigiri::s_verbosity`, to work with motis-project/motis#971.
Not sure why I didn't notice this before. But this will make it aligned with [`utl::log_verbosity`](https://github.com/motis-project/utl/blob/master/include/utl/logging.h#L27).

Does the variable needs to be renamed, as done for `utl::log_verbosity` (https://github.com/motis-project/utl/commit/b4d6a1be9635a246e6f2c90d5dcd1cc698087843)?