### PR TITLE
update claszes

### DIFF
--- a/include/nigiri/types.h
+++ b/include/nigiri/types.h
@@ -341,14 +341,14 @@ enum class clasz : std::uint8_t {
   kNight = 4,
   kRegionalFast = 5,
   kRegional = 6,
-  kMetro = 7,
+  kSuburban = 7,
   kSubway = 8,
   kTram = 9,
   kBus = 10,
   kShip = 11,
   kCableCar = 12,
   kFunicular = 13,
-  kAreaLift = 14,
+  kAerialLift = 14,
   kOther = 15,
   kNumClasses
 };

--- a/src/clasz.cc
+++ b/src/clasz.cc
@@ -114,7 +114,7 @@ clasz get_clasz(std::string_view s) {
     case hash("Metro"):
     case hash("Schnelles Nachtnetz"): [[fallthrough]];
     case hash("SN"):
-      return clasz::kMetro;  // S-Bahn Nachtlinie
+      return clasz::kSuburban;  // S-Bahn Nachtlinie
 
     // subway
     case hash("U"):
@@ -220,7 +220,8 @@ clasz to_clasz(std::string_view s) {
     case cista::hash("NIGHT"): return clasz::kNight;
     case cista::hash("REGIONALFAST"): return clasz::kRegionalFast;
     case cista::hash("REGIONAL"): return clasz::kRegional;
-    case cista::hash("METRO"): return clasz::kMetro;
+    case cista::hash("METRO"): return clasz::kSuburban;
+    case cista::hash("SUBURBAN"): return clasz::kSuburban;
     case cista::hash("SUBWAY"): return clasz::kSubway;
     case cista::hash("TRAM"): return clasz::kTram;
     case cista::hash("BUS"): return clasz::kBus;

--- a/src/loader/gtfs/route.cc
+++ b/src/loader/gtfs/route.cc
@@ -29,7 +29,7 @@ clasz to_clasz(std::uint16_t const route_type) {
     case 5 /* Cable tram. Used for street-level rail cars where the cable runs beneath the vehicle, e.g., cable car in San Francisco. */ :
       return clasz::kCableCar;
     case 6 /* Aerial lift, suspended cable car (e.g., gondola lift, aerial tramway). Cable transport where cabins, cars, gondolas or open chairs are suspended by means of one or more cables. */ :
-      return clasz::kAreaLift;
+      return clasz::kAerialLift;
     case 7 /* Funicular. Any rail system designed for steep inclines. */:
       return clasz::kFunicular;
     case 11 /* Trolleybus. Electric buses that draw power from overhead wires using poles. */ :
@@ -45,7 +45,7 @@ clasz to_clasz(std::uint16_t const route_type) {
     case 106 /* Regional Rail Service */:
     case 107 /* Tourist Railway Service */:
     case 108 /* Rail Shuttle (Within Complex) */: return clasz::kRegional;
-    case 109 /* Suburban Railway */: return clasz::kMetro;
+    case 109 /* Suburban Railway */: return clasz::kSuburban;
     case 110 /* Replacement Rail Service */:
     case 111 /* Special Rail Service */:
     case 112 /* Lorry Transport Rail Service */:
@@ -64,12 +64,12 @@ clasz to_clasz(std::uint16_t const route_type) {
     case 207 /* Tourist Coach Service */:
     case 208 /* Commuter Coach Service */:
     case 209 /* All Coach Services */: return clasz::kCoach;
-    case 400 /* Urban Railway Service */: return clasz::kSubway;
-    case 401 /* Metro Service */: return clasz::kMetro;
+    case 400 /* Urban Railway Service */:
+    case 401 /* Metro Service */:
     case 402 /* Underground Service */: return clasz::kSubway;
     case 403 /* Urban Railway Service */:
-    case 404 /* All Urban Railway Services */:
-    case 405 /* Monorail */: return clasz::kMetro;
+    case 404 /* All Urban Railway Services */: return clasz::kSuburban;
+    case 405 /* Monorail */: return clasz::kOther;
     case 700 /* Bus Service */:
     case 701 /* Regional Bus Service */:
     case 702 /* Express Bus Service */:
@@ -99,13 +99,13 @@ clasz to_clasz(std::uint16_t const route_type) {
     case 1100 /* Air Service */: return clasz::kAir;
     case 1200 /* Ferry Service */: return clasz::kShip;
     case 1300 /* Aerial Lift Service */:
-    case 1301 /* Telecabin Service */: return clasz::kAreaLift;
-    case 1302 /* Cable Car Service */: return clasz::kCableCar;
+    case 1301 /* Telecabin Service */: return clasz::kAerialLift;
+    case 1302 /* Cable Car Service */: return clasz::kAerialLift;
     case 1303 /* Elevator Service */: return clasz::kOther;
-    case 1304 /* Chair Lift Service */: return clasz::kAreaLift;
+    case 1304 /* Chair Lift Service */: return clasz::kAerialLift;
     case 1305 /* Drag Lift Service */: return clasz::kOther;
     case 1306 /* Small Telecabin Service */:
-    case 1307 /* All Telecabin Services */: return clasz::kAreaLift;
+    case 1307 /* All Telecabin Services */: return clasz::kAerialLift;
     case 1400 /* Funicular Service */: return clasz::kFunicular;
     case 1500 /* Taxi Service */:
     case 1501 /* Communal Taxi Service */:

--- a/src/loader/init_finish.cc
+++ b/src/loader/init_finish.cc
@@ -83,7 +83,7 @@ void assign_importance(timetable& tt) {
                                        /* Night */ 20,
                                        /* RegionalFast */ 16,
                                        /* Regional */ 15,
-                                       /* Metro */ 10,
+                                       /* Suburban */ 10,
                                        /* Subway */ 10,
                                        /* Tram */ 3,
                                        /* Bus  */ 2,

--- a/test/loader/hrd/category_test.cc
+++ b/test/loader/hrd/category_test.cc
@@ -20,7 +20,7 @@ s    4 C 0  S         0 N S-Bahn)";
     EXPECT_EQ((category{.name_ = "s",
                         .long_name_ = "S",
                         .output_rule_ = 0,
-                        .clasz_ = clasz::kMetro}),
+                        .clasz_ = clasz::kSuburban}),
               it->second);
   }
 }


### PR DESCRIPTION
proposition. `kMetro` -> `kSuburban` (S-Bahn, RER, Crossrail, suburban rail)
`kSubway` (Paris Metro, London Underground, but also NYC Subway, Hamburger Hochbahn, and other non-underground services)
closes #264 