### PR TITLE
separate additional trip ids per src

### DIFF
--- a/include/nigiri/rt/gtfsrt_resolve_run.h
+++ b/include/nigiri/rt/gtfsrt_resolve_run.h
@@ -97,6 +97,9 @@ std::pair<run, trip_idx_t> gtfsrt_resolve_run(
     transit_realtime::TripDescriptor const&,
     std::string_view rt_changed_trip_id = {});
 
-void resolve_rt(rt_timetable const&, run&, std::string_view trip_id);
+void resolve_rt(rt_timetable const&,
+                run&,
+                std::string_view trip_id,
+                source_idx_t src);
 
 }  // namespace nigiri::rt

--- a/include/nigiri/rt/rt_timetable.h
+++ b/include/nigiri/rt/rt_timetable.h
@@ -187,14 +187,15 @@ struct rt_timetable {
   // only works for transport that existed in the static timetable
   hash_map<transport, rt_transport_idx_t> static_trip_lookup_;
 
-  // Lookup: additional trip index -> realtime transport
-  vector_map<rt_add_trip_id_idx_t, rt_transport_idx_t> additional_trips_lookup_;
-
   // RT transport -> static transport (not for additional trips)
   vector_map<rt_transport_idx_t, variant<transport, rt_add_trip_id_idx_t>>
       rt_transport_static_transport_;
 
-  string_store<rt_add_trip_id_idx_t, source_idx_t> additional_trip_ids_;
+  struct additional_trips {
+    string_store<rt_add_trip_id_idx_t> ids_;
+    vector_map<rt_add_trip_id_idx_t, rt_transport_idx_t> transports_;
+  };
+  vector_map<source_idx_t, additional_trips> additional_trips_;
 
   vector_map<rt_transport_idx_t, source_idx_t> rt_transport_src_;
 

--- a/include/nigiri/rt/rt_timetable.h
+++ b/include/nigiri/rt/rt_timetable.h
@@ -194,7 +194,7 @@ struct rt_timetable {
   vector_map<rt_transport_idx_t, variant<transport, rt_add_trip_id_idx_t>>
       rt_transport_static_transport_;
 
-  string_store<rt_add_trip_id_idx_t> additional_trip_ids_;
+  string_store<rt_add_trip_id_idx_t, source_idx_t> additional_trip_ids_;
 
   vector_map<rt_transport_idx_t, source_idx_t> rt_transport_src_;
 

--- a/include/nigiri/string_store.h
+++ b/include/nigiri/string_store.h
@@ -4,51 +4,36 @@
 
 namespace nigiri {
 
-using none_tag_idx_t = cista::strong<std::uint8_t, struct _none_tag_idx_t>;
-
-template <typename Idx, typename TagIdx = none_tag_idx_t>
+template <typename Idx>
 struct string_store {
   using idx_t = Idx;
-  using tag_idx_t = TagIdx;
 
   struct hash {
     using is_transparent = void;
     cista::hash_t operator()(idx_t const i) const {
-      auto const h = cista::hash((*s_)[i].view());
-      return cista::hash_combine(
-          h, std::is_same<tag_idx_t, none_tag_idx_t>::value ? tag_idx_t{}.v_
-                                                            : (*t_)[i].v_);
+      return cista::hash((*s_)[i].view());
     }
-    cista::hash_t operator()(std::pair<std::string_view, tag_idx_t> k) const {
-      auto const h = cista::hash(k.first);
-      return cista::hash_combine(h, k.second.v_);
+    cista::hash_t operator()(std::string_view s) const {
+      return cista::hash(s);
     }
     ptr<vecvec<idx_t, char> const> s_;
-    ptr<vector_map<idx_t, tag_idx_t> const> t_;
   };
 
   struct equals {
     using is_transparent = void;
-    cista::hash_t operator()(std::pair<std::string_view, tag_idx_t> a,
-                             idx_t const b) const {
-      return a.first == (*s_)[b].view() &&
-             (std::is_same<tag_idx_t, none_tag_idx_t>::value ||
-              a.second == (*t_)[b]);
+    cista::hash_t operator()(std::string_view a, idx_t const b) const {
+      return a == (*s_)[b].view();
     }
     cista::hash_t operator()(idx_t const a, idx_t const b) const {
-      return (*s_)[a].view() == (*s_)[b].view() &&
-             (std::is_same<tag_idx_t, none_tag_idx_t>::value ||
-              (*t_)[a] == (*t_)[b]);
+      return (*s_)[a].view() == (*s_)[b].view();
     }
     ptr<vecvec<idx_t, char> const> s_;
-    ptr<vector_map<idx_t, tag_idx_t> const> t_;
   };
 
   string_store() = default;
   string_store(string_store const& o) {
     if (&o != this) {
       strings_ = o.strings_;
-      tags_ = o.tags_;
       cache_ = o.cache_;
       resolve();
     }
@@ -56,7 +41,6 @@ struct string_store {
   string_store(string_store&& o) {
     if (&o != this) {
       strings_ = std::move(o.strings_);
-      tags_ = std::move(o.tags_);
       cache_ = std::move(o.cache_);
       resolve();
     }
@@ -64,7 +48,6 @@ struct string_store {
   string_store& operator=(string_store const& o) {
     if (&o != this) {
       strings_ = o.strings_;
-      tags_ = o.tags_;
       cache_ = o.cache_;
       resolve();
     }
@@ -72,7 +55,6 @@ struct string_store {
   string_store& operator=(string_store&& o) {
     if (&o != this) {
       strings_ = std::move(o.strings_);
-      tags_ = std::move(o.tags_);
       cache_ = std::move(o.cache_);
       resolve();
     }
@@ -85,7 +67,7 @@ struct string_store {
     el->resolve();
   }
 
-  auto cista_members() { return std::tie(cache_, strings_, tags_); }
+  auto cista_members() { return std::tie(cache_, strings_); }
 
   std::string_view get(idx_t const x) const {
     return x == idx_t::invalid() ? "" : strings_[x].view();
@@ -95,37 +77,29 @@ struct string_store {
     return s == idx_t::invalid() ? std::nullopt : std::optional{get(s)};
   }
 
-  idx_t store(std::string_view str, tag_idx_t const tag = tag_idx_t{}) {
-    if (auto const it = cache_.find(std::pair{str, tag}); it != end(cache_)) {
+  idx_t store(std::string_view s) {
+    if (auto const it = cache_.find(s); it != end(cache_)) {
       return *it;
     } else {
       auto next = idx_t{strings_.size()};
-      strings_.emplace_back(str);
-      if (!std::is_same<tag_idx_t, none_tag_idx_t>::value) {
-        tags_.emplace_back(tag);
-      }
+      strings_.emplace_back(s);
       cache_.emplace(next);
       return next;
     }
   }
 
-  std::optional<idx_t> find(std::string_view str,
-                            tag_idx_t const tag = tag_idx_t{}) const {
-    auto const it = cache_.find(std::pair{str, tag});
+  std::optional<idx_t> find(std::string_view s) const {
+    auto const it = cache_.find(s);
     return it == end(cache_) ? std::nullopt : std::optional{*it};
   }
 
   void resolve() {
     cache_.hash_function().s_ = &strings_;
     cache_.key_eq().s_ = &strings_;
-    cache_.hash_function().t_ = &tags_;
-    cache_.key_eq().t_ = &tags_;
   }
 
   vecvec<idx_t, char> strings_;
-  vector_map<idx_t, tag_idx_t> tags_;
-  hash_set<idx_t, hash, equals> cache_{
-      0U, {&strings_, &tags_}, {&strings_, &tags_}};
+  hash_set<idx_t, hash, equals> cache_{0U, {&strings_}, {&strings_}};
 };
 
 }  // namespace nigiri

--- a/include/nigiri/string_store.h
+++ b/include/nigiri/string_store.h
@@ -4,36 +4,51 @@
 
 namespace nigiri {
 
-template <typename Idx>
+using none_tag_idx_t = cista::strong<std::uint8_t, struct _none_tag_idx_t>;
+
+template <typename Idx, typename TagIdx = none_tag_idx_t>
 struct string_store {
   using idx_t = Idx;
+  using tag_idx_t = TagIdx;
 
   struct hash {
     using is_transparent = void;
     cista::hash_t operator()(idx_t const i) const {
-      return cista::hash((*s_)[i].view());
+      auto const h = cista::hash((*s_)[i].view());
+      return cista::hash_combine(
+          h, std::is_same<tag_idx_t, none_tag_idx_t>::value ? tag_idx_t{}.v_
+                                                            : (*t_)[i].v_);
     }
-    cista::hash_t operator()(std::string_view s) const {
-      return cista::hash(s);
+    cista::hash_t operator()(std::pair<std::string_view, tag_idx_t> k) const {
+      auto const h = cista::hash(k.first);
+      return cista::hash_combine(h, k.second.v_);
     }
     ptr<vecvec<idx_t, char> const> s_;
+    ptr<vector_map<idx_t, tag_idx_t> const> t_;
   };
 
   struct equals {
     using is_transparent = void;
-    cista::hash_t operator()(std::string_view a, idx_t const b) const {
-      return a == (*s_)[b].view();
+    cista::hash_t operator()(std::pair<std::string_view, tag_idx_t> a,
+                             idx_t const b) const {
+      return a.first == (*s_)[b].view() &&
+             (std::is_same<tag_idx_t, none_tag_idx_t>::value ||
+              a.second == (*t_)[b]);
     }
     cista::hash_t operator()(idx_t const a, idx_t const b) const {
-      return (*s_)[a].view() == (*s_)[b].view();
+      return (*s_)[a].view() == (*s_)[b].view() &&
+             (std::is_same<tag_idx_t, none_tag_idx_t>::value ||
+              (*t_)[a] == (*t_)[b]);
     }
     ptr<vecvec<idx_t, char> const> s_;
+    ptr<vector_map<idx_t, tag_idx_t> const> t_;
   };
 
   string_store() = default;
   string_store(string_store const& o) {
     if (&o != this) {
       strings_ = o.strings_;
+      tags_ = o.tags_;
       cache_ = o.cache_;
       resolve();
     }
@@ -41,6 +56,7 @@ struct string_store {
   string_store(string_store&& o) {
     if (&o != this) {
       strings_ = std::move(o.strings_);
+      tags_ = std::move(o.tags_);
       cache_ = std::move(o.cache_);
       resolve();
     }
@@ -48,6 +64,7 @@ struct string_store {
   string_store& operator=(string_store const& o) {
     if (&o != this) {
       strings_ = o.strings_;
+      tags_ = o.tags_;
       cache_ = o.cache_;
       resolve();
     }
@@ -55,6 +72,7 @@ struct string_store {
   string_store& operator=(string_store&& o) {
     if (&o != this) {
       strings_ = std::move(o.strings_);
+      tags_ = std::move(o.tags_);
       cache_ = std::move(o.cache_);
       resolve();
     }
@@ -67,7 +85,7 @@ struct string_store {
     el->resolve();
   }
 
-  auto cista_members() { return std::tie(cache_, strings_); }
+  auto cista_members() { return std::tie(cache_, strings_, tags_); }
 
   std::string_view get(idx_t const x) const {
     return x == idx_t::invalid() ? "" : strings_[x].view();
@@ -77,29 +95,37 @@ struct string_store {
     return s == idx_t::invalid() ? std::nullopt : std::optional{get(s)};
   }
 
-  idx_t store(std::string_view s) {
-    if (auto const it = cache_.find(s); it != end(cache_)) {
+  idx_t store(std::string_view str, tag_idx_t const tag = tag_idx_t{}) {
+    if (auto const it = cache_.find(std::pair{str, tag}); it != end(cache_)) {
       return *it;
     } else {
       auto next = idx_t{strings_.size()};
-      strings_.emplace_back(s);
+      strings_.emplace_back(str);
+      if (!std::is_same<tag_idx_t, none_tag_idx_t>::value) {
+        tags_.emplace_back(tag);
+      }
       cache_.emplace(next);
       return next;
     }
   }
 
-  std::optional<idx_t> find(std::string_view s) const {
-    auto const it = cache_.find(s);
+  std::optional<idx_t> find(std::string_view str,
+                            tag_idx_t const tag = tag_idx_t{}) const {
+    auto const it = cache_.find(std::pair{str, tag});
     return it == end(cache_) ? std::nullopt : std::optional{*it};
   }
 
   void resolve() {
     cache_.hash_function().s_ = &strings_;
     cache_.key_eq().s_ = &strings_;
+    cache_.hash_function().t_ = &tags_;
+    cache_.key_eq().t_ = &tags_;
   }
 
   vecvec<idx_t, char> strings_;
-  hash_set<idx_t, hash, equals> cache_{0U, {&strings_}, {&strings_}};
+  vector_map<idx_t, tag_idx_t> tags_;
+  hash_set<idx_t, hash, equals> cache_{
+      0U, {&strings_, &tags_}, {&strings_, &tags_}};
 };
 
 }  // namespace nigiri

--- a/src/rt/create_rt_timetable.cc
+++ b/src/rt/create_rt_timetable.cc
@@ -31,6 +31,7 @@ rt_timetable create_rt_timetable(timetable const& tt,
       rtt.td_footpaths_in_[i].resize(tt.n_locations());
     }
   }
+  rtt.additional_trips_.resize(tt.n_sources());
   return rtt;
 }
 

--- a/src/rt/frun.cc
+++ b/src/rt/frun.cc
@@ -718,8 +718,8 @@ trip_id frun::id() const {
                  rtt_->rt_transport_static_transport_[rt_])) {
     auto const add_idx =
         rtt_->rt_transport_static_transport_[rt_].as<rt_add_trip_id_idx_t>();
-    return {rtt_->additional_trip_ids_.get(add_idx),
-            rtt_->rt_transport_src_[rt_]};
+    auto const src = rtt_->rt_transport_src_[rt_];
+    return {rtt_->additional_trips_.at(src).ids_.get(add_idx), src};
   } else {
     return {};
   }

--- a/src/rt/gtfsrt_resolve_run.cc
+++ b/src/rt/gtfsrt_resolve_run.cc
@@ -41,9 +41,9 @@ void resolve_rt(rt_timetable const& rtt,
     return;
   }
   auto const rt_add_idx =
-      rtt.additional_trip_ids_.find(rt_changed_trip_id, src);
+      rtt.additional_trips_.at(src).ids_.find(rt_changed_trip_id);
   if (rt_add_idx.has_value()) {
-    output.rt_ = rtt.additional_trips_lookup_[*rt_add_idx];
+    output.rt_ = rtt.additional_trips_.at(src).transports_[*rt_add_idx];
     if (output.stop_range_.size() == 0) {
       output.stop_range_ = {
           static_cast<stop_idx_t>(0U),

--- a/src/rt/gtfsrt_resolve_run.cc
+++ b/src/rt/gtfsrt_resolve_run.cc
@@ -30,7 +30,8 @@ void resolve_static(date::sys_days const today,
 
 void resolve_rt(rt_timetable const& rtt,
                 run& output,
-                std::string_view rt_changed_trip_id) {
+                std::string_view rt_changed_trip_id,
+                source_idx_t const src) {
   auto const it = rtt.static_trip_lookup_.find(output.t_);
   if (it != end(rtt.static_trip_lookup_)) {
     output.rt_ = it->second;
@@ -39,7 +40,8 @@ void resolve_rt(rt_timetable const& rtt,
   if (output.is_scheduled()) {
     return;
   }
-  auto const rt_add_idx = rtt.additional_trip_ids_.find(rt_changed_trip_id);
+  auto const rt_add_idx =
+      rtt.additional_trip_ids_.find(rt_changed_trip_id, src);
   if (rt_add_idx.has_value()) {
     output.rt_ = rtt.additional_trips_lookup_[*rt_add_idx];
     if (output.stop_range_.size() == 0) {
@@ -63,7 +65,8 @@ std::pair<run, trip_idx_t> gtfsrt_resolve_run(
   resolve_static(today, tt, src, td, r, trip);
   if (rtt != nullptr) {
     resolve_rt(*rtt, r,
-               rt_changed_trip_id.empty() ? td.trip_id() : rt_changed_trip_id);
+               rt_changed_trip_id.empty() ? td.trip_id() : rt_changed_trip_id,
+               src);
   }
   return {r, trip};
 }

--- a/src/rt/gtfsrt_update.cc
+++ b/src/rt/gtfsrt_update.cc
@@ -703,12 +703,12 @@ statistics gtfsrt_update_msg(timetable const& tt,
       resolve_static(today, tt, src, td, [&](run r, trip_idx_t const trip) {
         is_resolved_static = true;
 
-        resolve_rt(rtt, r, trip_id);
+        resolve_rt(rtt, r, trip_id, src);
 
         if (sr == gtfsrt::TripDescriptor_ScheduleRelationship_CANCELED) {
           rtt.cancel_run(r);
           ++stats.total_entities_success_;
-        } else {
+        } else if (!added) {
           if (update_run(src, tt, rtt, trip, r, entity.trip_update())) {
             ++stats.total_entities_success_;
           }
@@ -721,7 +721,7 @@ statistics gtfsrt_update_msg(timetable const& tt,
         utl::verify(!is_resolved_static,
                     "NEW/ADDED trip is required to have a new trip_id");
         auto r = rt::run{};
-        resolve_rt(rtt, r, trip_id.empty() ? td.trip_id() : trip_id);
+        resolve_rt(rtt, r, trip_id.empty() ? td.trip_id() : trip_id, src);
         if (update_run(src, tt, rtt, trip_idx_t::invalid(), r,
                        entity.trip_update())) {
           ++stats.total_entities_success_;

--- a/src/rt/rt_timetable.cc
+++ b/src/rt/rt_timetable.cc
@@ -26,9 +26,9 @@ rt_transport_idx_t rt_timetable::add_rt_transport(
     transport_traffic_days_[t_idx] = bitfield_idx_t{bitfields_.size() - 1U};
   } else {
     auto const rt_add_idx =
-        rt_add_trip_id_idx_t{additional_trips_lookup_.size()};
-    additional_trips_lookup_.emplace_back(rt_t_idx);
-    additional_trip_ids_.store(new_trip_id, src);
+        rt_add_trip_id_idx_t{additional_trips_.at(src).transports_.size()};
+    additional_trips_.at(src).ids_.store(new_trip_id);
+    additional_trips_.at(src).transports_.emplace_back(rt_t_idx);
     rt_transport_static_transport_.emplace_back(rt_add_idx);
   }
 
@@ -122,13 +122,13 @@ rt_transport_idx_t rt_timetable::add_rt_transport(
 
   assert(time_seq.empty() || time_seq.size() == location_seq.size() * 2U - 2U);
   assert(static_trip_lookup_.contains(t) ||
-         additional_trip_ids_.find(new_trip_id, src).has_value());
+         additional_trips_.at(src).ids_.find(new_trip_id).has_value());
   assert(rt_transport_static_transport_[rt_transport_idx_t{rt_t_idx}] == t ||
          rt_transport_static_transport_[rt_transport_idx_t{rt_t_idx}] ==
-             rt_add_trip_id_idx_t{additional_trips_lookup_.size() - 1U});
-  assert(additional_trips_lookup_.size() ==
-         additional_trip_ids_.strings_.size());
-  assert(additional_trips_lookup_.size() == additional_trip_ids_.tags_.size());
+             rt_add_trip_id_idx_t{additional_trips_.at(src).transports_.size() -
+                                  1U});
+  assert(additional_trips_.at(src).transports_.size() ==
+         additional_trips_.at(src).ids_.strings_.size());
   assert(rt_transport_static_transport_.size() == rt_t_idx + 1U);
   assert(rt_transport_src_.size() == rt_t_idx + 1U);
   assert(rt_transport_route_id_.size() == rt_t_idx + 1U);

--- a/src/rt/rt_timetable.cc
+++ b/src/rt/rt_timetable.cc
@@ -28,7 +28,7 @@ rt_transport_idx_t rt_timetable::add_rt_transport(
     auto const rt_add_idx =
         rt_add_trip_id_idx_t{additional_trips_lookup_.size()};
     additional_trips_lookup_.emplace_back(rt_t_idx);
-    additional_trip_ids_.store(new_trip_id);
+    additional_trip_ids_.store(new_trip_id, src);
     rt_transport_static_transport_.emplace_back(rt_add_idx);
   }
 
@@ -122,12 +122,13 @@ rt_transport_idx_t rt_timetable::add_rt_transport(
 
   assert(time_seq.empty() || time_seq.size() == location_seq.size() * 2U - 2U);
   assert(static_trip_lookup_.contains(t) ||
-         additional_trip_ids_.find(new_trip_id).has_value());
+         additional_trip_ids_.find(new_trip_id, src).has_value());
   assert(rt_transport_static_transport_[rt_transport_idx_t{rt_t_idx}] == t ||
          rt_transport_static_transport_[rt_transport_idx_t{rt_t_idx}] ==
              rt_add_trip_id_idx_t{additional_trips_lookup_.size() - 1U});
   assert(additional_trips_lookup_.size() ==
          additional_trip_ids_.strings_.size());
+  assert(additional_trips_lookup_.size() == additional_trip_ids_.tags_.size());
   assert(rt_transport_static_transport_.size() == rt_t_idx + 1U);
   assert(rt_transport_src_.size() == rt_t_idx + 1U);
   assert(rt_transport_route_id_.size() == rt_t_idx + 1U);

--- a/test/rt/gtfsrt_added_test.cc
+++ b/test/rt/gtfsrt_added_test.cc
@@ -508,6 +508,53 @@ auto const kTripNewRelative =
  ]
 })"s;
 
+auto const kTripNewWithSameId =
+    R"({
+ "header": {
+  "gtfsRealtimeVersion": "2.0",
+  "incrementality": "FULL_DATASET",
+  "timestamp": "1691660324"
+ },
+ "entity": [
+  {
+    "id": "3248651",
+    "isDeleted": false,
+    "tripUpdate": {
+     "trip": {
+      "tripId": "TRIP_1",
+      "startTime": "10:00:00",
+      "startDate": "20230810",
+      "scheduleRelationship": "NEW"
+     },
+     "stopTimeUpdate": [
+      {
+       "stopSequence": 1,
+       "arrival": {
+        "time": "1691658900"
+       },
+       "departure": {
+        "time": "1691658900"
+       },
+       "stopId": "E",
+       "scheduleRelationship": "SCHEDULED"
+      },
+      {
+       "stopSequence": 2,
+       "arrival": {
+        "time": "1691658960"
+       },
+       "departure": {
+        "time": "1691658960"
+       },
+       "stopId": "D",
+       "scheduleRelationship": "SKIPPED"
+      }
+     ]
+    }
+  }
+ ]
+})"s;
+
 auto const kTripReplacement =
     R"({
  "header": {
@@ -888,6 +935,70 @@ TEST(rt, gtfs_rt_new) {
   ss << "\n" << fr;
   EXPECT_EQ(1, rtt.rt_transport_location_seq_.size());
   EXPECT_EQ(expectedNewLonger, ss.str());
+}
+
+TEST(rt, gtfs_rt_new_different_source) {
+  // Load static timetable.
+  timetable tt;
+  register_special_stations(tt);
+  tt.date_range_ = {date::sys_days{2023_y / August / 9},
+                    date::sys_days{2023_y / August / 12}};
+  load_timetable({}, source_idx_t{0}, test_files(), tt);
+  load_timetable({}, source_idx_t{1}, test_files(), tt);
+  finalize(tt);
+
+  // Create empty RT timetable.
+  auto rtt = rt::create_rt_timetable(tt, date::sys_days{2023_y / August / 10});
+
+  // Update.
+  auto const msg = rt::json_to_protobuf(kTripNew);
+  gtfsrt_update_buf(tt, rtt, source_idx_t{1}, "", msg);
+
+  // Print trip.
+  transit_realtime::TripDescriptor td;
+  td.set_start_date("20230811");
+  td.set_trip_id("TRIP_NEW");
+  td.set_start_time("10:00:00");
+
+  {
+    auto const [r, t] = rt::gtfsrt_resolve_run(
+        date::sys_days{2023_y / August / 11}, tt, &rtt, source_idx_t{0}, td);
+    ASSERT_FALSE(r.valid());
+  }
+  {
+    auto const [r, t] = rt::gtfsrt_resolve_run(
+        date::sys_days{2023_y / August / 11}, tt, &rtt, source_idx_t{1}, td);
+    ASSERT_TRUE(r.valid());
+  }
+}
+
+TEST(rt, gtfs_rt_new_with_existing_trip_id) {
+  // Load static timetable.
+  timetable tt;
+  register_special_stations(tt);
+  tt.date_range_ = {date::sys_days{2023_y / August / 9},
+                    date::sys_days{2023_y / August / 12}};
+  load_timetable({}, source_idx_t{0}, test_files(), tt);
+  finalize(tt);
+
+  // Create empty RT timetable.
+  auto rtt = rt::create_rt_timetable(tt, date::sys_days{2023_y / August / 10});
+
+  // Update.
+  auto const msg = rt::json_to_protobuf(kTripNewWithSameId);
+  gtfsrt_update_buf(tt, rtt, source_idx_t{0}, "", msg);
+
+  // Print trip.
+  transit_realtime::TripDescriptor td;
+  td.set_start_date("20230810");
+  td.set_trip_id("TRIP_1");
+  td.set_start_time("10:00:00");
+
+  auto const [r, t] = rt::gtfsrt_resolve_run(
+      date::sys_days{2023_y / August / 10}, tt, &rtt, source_idx_t{0}, td);
+  ASSERT_TRUE(r.valid());
+  auto const fr = rt::frun{tt, &rtt, r};
+  EXPECT_FALSE(fr.is_rt());
 }
 
 TEST(rt, gtfs_rt_new_no_route) {

--- a/test/rt/gtfsrt_resolve_trip_test.cc
+++ b/test/rt/gtfsrt_resolve_trip_test.cc
@@ -230,6 +230,7 @@ TEST(rt, gtfs_rt_update) {
   rtt.base_day_ = date::sys_days{2019_y / May / 3};
   rtt.base_day_idx_ = tt.day_idx(rtt.base_day_);
   rtt.location_rt_transports_[location_idx_t{tt.n_locations() - 1U}];
+  rtt.additional_trips_.resize(tt.n_sources());
 
   // Create basic update message.
   transit_realtime::FeedMessage msg;


### PR DESCRIPTION
solution: extend `string_store` to support an optional additional tag/src (other propositions?)
more regression testing (fares, alerts, but also trip updates) would probably be good... 