### PR TITLE
Use black or white route text color if contrast is too low

### DIFF
--- a/src/loader/init_finish.cc
+++ b/src/loader/init_finish.cc
@@ -98,6 +98,53 @@ void assign_importance(timetable& tt) {
   }
 }
 
+// Based on https://www.w3.org/TR/WCAG20/#relativeluminancedef
+float luminance(color_t color) {
+  constexpr auto max = static_cast<float>(std::numeric_limits<uint8_t>::max());
+  auto const r = (color.v_ >> 16 & 0xFF) / max;
+  auto const g = (color.v_ >> 8 & 0xFF) / max;
+  auto const b = (color.v_ & 0xFF) / max;
+
+  auto const color_lum = [](float channel) -> float {
+    return channel <= 0.03928f ? channel / 12.92f
+                               : std::pow((channel + 0.055f) / 1.055f, 2.4f);
+  };
+  auto const red_lum = color_lum(r);
+  auto const green_lum = color_lum(g);
+  auto const blue_lum = color_lum(b);
+
+  return 0.2126f * red_lum + 0.7152f * green_lum + 0.0722f * blue_lum;
+}
+
+// Based on contrast ratio formula from https://www.w3.org/TR/WCAG20/
+float contrast_ratio(color_t a, color_t b) {
+  auto const a_lum = luminance(a);
+  auto const b_lum = luminance(b);
+
+  auto const [lighter, darker] =
+      a_lum > b_lum ? std::tuple{a_lum, b_lum} : std::tuple{b_lum, a_lum};
+
+  return (lighter + 0.05f) / (darker + 0.05f);
+}
+
+void correct_color_contrast(timetable& tt) {
+  for (auto const bucket : tt.transport_section_route_colors_) {
+    for (auto& colors : bucket) {
+      auto const ratio = contrast_ratio(colors.color_, colors.text_color_);
+
+      if (ratio < 4.5f) {
+        constexpr auto white = color_t(0xFFFFFF);
+        constexpr auto black = color_t(0x000000);
+        auto const better = contrast_ratio(colors.color_, black) >
+                                    contrast_ratio(colors.color_, white)
+                                ? black
+                                : white;
+        colors.text_color_ = better;
+      }
+    }
+  }
+}
+
 void finalize(timetable& tt, finalize_options const opt) {
   tt.strings_.cache_.clear();
   tt.location_routes_.resize(tt.n_locations());
@@ -135,6 +182,7 @@ void finalize(timetable& tt, finalize_options const opt) {
   build_location_tree(tt);
   assign_stops_to_flex_areas(tt);
   assign_importance(tt);
+  correct_color_contrast(tt);
 
   log(log_lvl::info, "nigiri.loader.finalize",
       "{} locations ({}% of idx space used)", tt.n_locations(),


### PR DESCRIPTION
A good test case is https://api.transitous.org/gtfs/ua_lviv.gtfs.zip

Before:
<img width="518" height="336" alt="image" src="https://github.com/user-attachments/assets/cef12396-344d-4d05-b338-31da92e0ccb8" />

After:
<img width="518" height="294" alt="image" src="https://github.com/user-attachments/assets/b42387f6-3e0e-4f84-9050-189ab294eedf" />

The color processing will probably not work correctly on big endian, do we care?

The minimum contrast is taken from [here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable/Color_contrast), it might make sense to use the value for icons instead in case this breaks any okay branding.