### PR TITLE
Reduce minimum contrast to 3.0

### DIFF
--- a/src/loader/init_finish.cc
+++ b/src/loader/init_finish.cc
@@ -136,7 +136,7 @@ void correct_color_contrast(timetable& tt) {
     for (auto& colors : ids.route_id_colors_) {
       auto const ratio = contrast_ratio(colors.color_, colors.text_color_);
 
-      if (ratio < 4.5f) {
+      if (ratio < 3.0f) {
         constexpr auto white = color_t(0xFFFFFF);
         constexpr auto black = color_t(0x000000);
         auto const better = contrast_ratio(colors.color_, black) >


### PR DESCRIPTION
This is the recommended value for icons.
4.5 broke some brand colors that are still okay for the route badges.

An example is the LTG Link branding:
background: #F8423A, foreground: #F0F0F0