### PR TITLE
Add get_first_trip_stop function for run_stop

### DIFF
--- a/include/nigiri/rt/frun.h
+++ b/include/nigiri/rt/frun.h
@@ -46,6 +46,7 @@ struct run_stop {
   std::string_view route_long_name(event_type, lang_t const&) const;
   std::string_view trip_short_name(event_type, lang_t const&) const;
   std::string_view display_name(event_type, lang_t const&) const;
+  run_stop get_first_trip_stop(event_type) const;
   run_stop get_last_trip_stop(event_type) const;
 
   unixtime_t scheduled_time(event_type) const;

--- a/src/rt/frun.cc
+++ b/src/rt/frun.cc
@@ -123,6 +123,25 @@ location_idx_t run_stop::get_scheduled_location_idx() const {
   return get_scheduled_stop().location_idx();
 }
 
+run_stop run_stop::get_first_trip_stop(event_type const ev_type) const {
+  if (!fr_->is_scheduled()) {
+    return run_stop{fr_, stop_idx_t{0U}};
+  }
+
+  auto const trip = get_trip_idx(ev_type);
+  auto copy = *this;
+
+  while (copy.stop_idx_ > 0U && copy.get_trip_idx(event_type::kDep) == trip) {
+    --copy.stop_idx_;
+  }
+
+  if (copy.get_trip_idx(event_type::kDep) != trip) {
+    ++copy.stop_idx_;
+  }
+
+  return copy;
+}
+
 run_stop run_stop::get_last_trip_stop(event_type const ev_type) const {
   auto const end = fr_->size();
   if (!fr_->is_scheduled()) {


### PR DESCRIPTION
This PR adds a `get_first_trip_stop` function for `run_stop` the same way `get_last_trip_stop` already exists.

I merely copied the structure of `get_last_trip_stop`, adapted it for the first stop case, and simplified a little bit the function (contrary to `get_last_trip_stop` that needs to do some index checks because of `section_idx` using `stop_idx_ - 1`, `get_first_trip_stop` only depends on `stop_idx_` so less boundary checks need to be done).

Please proofread carefully my yet simple PR. I have little experience with all the nigiri code.