### PR TITLE
Implement missing method 'raptor_state::get_tmp() const'

### DIFF
--- a/include/nigiri/routing/raptor/raptor_state.h
+++ b/include/nigiri/routing/raptor/raptor_state.h
@@ -42,6 +42,13 @@ struct raptor_state {
   }
 
   template <via_offset_t Vias>
+  std::span<std::array<delta_t, Vias + 1> const> get_tmp() const {
+    return {reinterpret_cast<std::array<delta_t, Vias + 1> const*>(
+                tmp_storage_.data()),
+            n_locations_};
+  }
+
+  template <via_offset_t Vias>
   std::span<std::array<delta_t, Vias + 1>> get_best() {
     return {
         reinterpret_cast<std::array<delta_t, Vias + 1>*>(best_storage_.data()),


### PR DESCRIPTION
This adds a `const` version for `raptor_state::get_tmp()`, as all other methods already have a `const` version.