### PR TITLE
range raptor early termination

### DIFF
--- a/include/nigiri/routing/search.h
+++ b/include/nigiri/routing/search.h
@@ -54,6 +54,8 @@ struct search_stats {
         {"execute_time", execute_time_.count()},
         {"n_events_skipped_by_early_termination",
          n_events_skipped_by_early_termination_},
+        {"search_interval_reduction_by_early_termination",
+         search_interval_reduction_by_early_termination_.count()},
     };
   }
 
@@ -501,7 +503,7 @@ private:
               search_interval_.to_ = start_time + duration_t{1};
             }
             stats_.search_interval_reduction_by_early_termination_ =
-                start_size - search_interval_.size();
+                std::chrono::abs(start_size - search_interval_.size());
           }
         });
   }


### PR DESCRIPTION
for range queries: 
stop searching the interval in case of a non-zero min. connection count being already reached and
 - search dir == fwd && extend allowed only earlier
 - search dir == bwd && extend allowed only later

all algorithms used by search.h should support this, PONG is not affected since it implements its own search approach