### PR TITLE
Lower-bound RAPTOR

### DIFF
--- a/include/nigiri/loader/build_lb_adjacency.h
+++ b/include/nigiri/loader/build_lb_adjacency.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "nigiri/timetable.h"
+#include "nigiri/types.h"
+
+namespace nigiri::loader {
+
+void build_lb_adjacency(timetable&, profile_idx_t);
+
+}  // namespace nigiri::loader

--- a/include/nigiri/routing/lb_raptor.h
+++ b/include/nigiri/routing/lb_raptor.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "nigiri/routing/limits.h"
+#include "nigiri/types.h"
+
+namespace nigiri {
+struct timetable;
+struct footpath;
+}  // namespace nigiri
+
+namespace nigiri::routing {
+struct query;
+
+void lb_raptor(
+    timetable const&,
+    query const&,
+    vecvec<location_idx_t, footpath> const& lb_graph,
+    bitvec_map<location_idx_t> const* has_rt,
+    vecvec<location_idx_t, footpath> const* rt_lb_graph,
+    vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2>>&
+        location_round_lb);
+
+}  // namespace nigiri::routing

--- a/include/nigiri/routing/lb_raptor.h
+++ b/include/nigiri/routing/lb_raptor.h
@@ -11,14 +11,44 @@ struct footpath;
 namespace nigiri::routing {
 struct query;
 
+static constexpr auto kUnreachable = std::numeric_limits<std::uint16_t>::max();
+
+struct lb_raptor_state {
+  void resize(unsigned const n) {
+    location_round_lb_.resize(n);
+    station_mark_.resize(n);
+    prev_station_mark_.resize(n);
+    is_start_.resize(n);
+  }
+
+  void clear() {
+    static constexpr auto kRoundLbInit = []() {
+      auto ret = std::array<std::uint16_t, kMaxTransfers + 2>{};
+      ret.fill(kUnreachable);
+      return ret;
+    }();
+    utl::fill(location_round_lb_, kRoundLbInit);
+    utl::fill(station_mark_.blocks_, 0U);
+    utl::fill(is_start_.blocks_, 0U);
+  }
+
+  void zeroize() {
+    static constexpr auto kLbZero = [] {
+      auto a = std::array<std::uint16_t, kMaxTransfers + 2U>{};
+      a.fill(0U);
+      return a;
+    }();
+    utl::fill(location_round_lb_, kLbZero);
+  }
+
+  vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>
+      location_round_lb_;
+  bitvec station_mark_;
+  bitvec prev_station_mark_;
+  bitvec is_start_;
+};
+
 template <direction SearchDir>
-void lb_raptor(
-    timetable const&,
-    query const&,
-    bitvec& station_mark,
-    bitvec& prev_station_mark,
-    bitvec& is_start,
-    vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>&
-        location_round_lb);
+void lb_raptor(timetable const&, query const&, lb_raptor_state&);
 
 }  // namespace nigiri::routing

--- a/include/nigiri/routing/lb_raptor.h
+++ b/include/nigiri/routing/lb_raptor.h
@@ -19,7 +19,7 @@ void lb_raptor(
     bitvec_map<location_idx_t> const* has_rt,
     vecvec<location_idx_t, footpath> const* rt_lb_graph,
     raptor_state&,
-    vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2>>&
+    vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>&
         location_round_lb);
 
 }  // namespace nigiri::routing

--- a/include/nigiri/routing/lb_raptor.h
+++ b/include/nigiri/routing/lb_raptor.h
@@ -10,13 +10,14 @@ struct footpath;
 
 namespace nigiri::routing {
 struct query;
-struct raptor_state;
 
 template <direction SearchDir>
 void lb_raptor(
     timetable const&,
     query const&,
-    raptor_state&,
+    bitvec& station_mark,
+    bitvec& prev_station_mark,
+    bitvec& is_start,
     vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>&
         location_round_lb);
 

--- a/include/nigiri/routing/lb_raptor.h
+++ b/include/nigiri/routing/lb_raptor.h
@@ -10,6 +10,7 @@ struct footpath;
 
 namespace nigiri::routing {
 struct query;
+struct raptor_state;
 
 void lb_raptor(
     timetable const&,
@@ -17,6 +18,7 @@ void lb_raptor(
     vecvec<location_idx_t, footpath> const& lb_graph,
     bitvec_map<location_idx_t> const* has_rt,
     vecvec<location_idx_t, footpath> const* rt_lb_graph,
+    raptor_state&,
     vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2>>&
         location_round_lb);
 

--- a/include/nigiri/routing/lb_raptor.h
+++ b/include/nigiri/routing/lb_raptor.h
@@ -12,12 +12,10 @@ namespace nigiri::routing {
 struct query;
 struct raptor_state;
 
+template <direction SearchDir>
 void lb_raptor(
     timetable const&,
     query const&,
-    vecvec<location_idx_t, footpath> const& lb_graph,
-    bitvec_map<location_idx_t> const* has_rt,
-    vecvec<location_idx_t, footpath> const* rt_lb_graph,
     raptor_state&,
     vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>&
         location_round_lb);

--- a/include/nigiri/routing/raptor/raptor.h
+++ b/include/nigiri/routing/raptor/raptor.h
@@ -5,6 +5,7 @@
 #include "nigiri/common/delta_t.h"
 #include "nigiri/common/linear_lower_bound.h"
 #include "nigiri/routing/journey.h"
+#include "nigiri/routing/lb_raptor.h"
 #include "nigiri/routing/limits.h"
 #include "nigiri/routing/pareto_set.h"
 #include "nigiri/routing/raptor/debug.h"
@@ -74,14 +75,12 @@ struct raptor {
   using algo_stats_t = raptor_stats;
 
   static constexpr bool kUseLowerBounds = true;
-  static constexpr auto const kFwd = (SearchDir == direction::kForward);
-  static constexpr auto const kBwd = (SearchDir == direction::kBackward);
-  static constexpr auto const kInvalid = kInvalidDelta<SearchDir>;
-  static constexpr auto const kUnreachable =
-      std::numeric_limits<std::uint16_t>::max();
-  static constexpr auto const kIntermodalTarget =
+  static constexpr auto kFwd = (SearchDir == direction::kForward);
+  static constexpr auto kBwd = (SearchDir == direction::kBackward);
+  static constexpr auto kInvalid = kInvalidDelta<SearchDir>;
+  static constexpr auto kIntermodalTarget =
       to_idx(get_special_station(special_station::kEnd));
-  static constexpr auto const kInvalidArray = []() {
+  static constexpr auto kInvalidArray = []() {
     auto a = std::array<delta_t, Vias + 1>{};
     a.fill(kInvalid);
     return a;
@@ -104,7 +103,8 @@ struct raptor {
       std::array<bitvec, kMaxVias>& is_via,
       std::vector<std::uint16_t>& dist_to_dest,
       hash_map<location_idx_t, std::vector<td_offset>> const& td_dist_to_dest,
-      std::vector<std::uint16_t>& lb,
+      vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>&
+          location_round_lb,
       std::vector<via_stop> const& via_stops,
       day_idx_t const base,
       clasz_mask_t const allowed_claszes,
@@ -126,7 +126,7 @@ struct raptor {
         is_via_{is_via},
         dist_to_end_{dist_to_dest},
         td_dist_to_end_{td_dist_to_dest},
-        lb_{lb},
+        location_round_lb_{location_round_lb},
         via_stops_{via_stops},
         base_{base},
         allowed_claszes_{allowed_claszes},
@@ -198,6 +198,7 @@ struct raptor {
     trace_print_init_state();
 
     for (auto k = 1U; k != end_k; ++k) {
+      auto const remaining_k = end_k - k;
       for (auto i = 0U; i != n_locations_; ++i) {
         for (auto v = 0U; v != Vias + 1; ++v) {
           best_[i][v] = get_best(round_times_[k][i][v], best_[i][v]);
@@ -230,39 +231,47 @@ struct raptor {
       std::swap(state_.prev_station_mark_, state_.station_mark_);
       utl::fill(state_.station_mark_.blocks_, 0U);
 
-      any_marked = (allowed_claszes_ == all_clasz_allowed())
-                       ? (require_bike_transport_
-                              ? (require_car_transport_
-                                     ? loop_routes<false, true, true>(k)
-                                     : loop_routes<false, true, false>(k))
-                              : (require_car_transport_
-                                     ? loop_routes<false, false, true>(k)
-                                     : loop_routes<false, false, false>(k)))
-                       : (require_bike_transport_
-                              ? (require_car_transport_
-                                     ? loop_routes<true, true, true>(k)
-                                     : loop_routes<true, true, false>(k))
-                              : (require_car_transport_
-                                     ? loop_routes<true, false, true>(k)
-                                     : loop_routes<true, false, false>(k)));
+      any_marked =
+          (allowed_claszes_ == all_clasz_allowed())
+              ? (require_bike_transport_
+                     ? (require_car_transport_
+                            ? loop_routes<false, true, true>(k, remaining_k)
+                            : loop_routes<false, true, false>(k, remaining_k))
+                     : (require_car_transport_
+                            ? loop_routes<false, false, true>(k, remaining_k)
+                            : loop_routes<false, false, false>(k, remaining_k)))
+              : (require_bike_transport_
+                     ? (require_car_transport_
+                            ? loop_routes<true, true, true>(k, remaining_k)
+                            : loop_routes<true, true, false>(k, remaining_k))
+                     : (require_car_transport_
+                            ? loop_routes<true, false, true>(k, remaining_k)
+                            : loop_routes<true, false, false>(k, remaining_k)));
 
       if constexpr (Rt) {
         any_marked |=
             (allowed_claszes_ == all_clasz_allowed())
                 ? (require_bike_transport_
                        ? (require_car_transport_
-                              ? loop_rt_routes<false, true, true>(k)
-                              : loop_rt_routes<false, true, false>(k))
+                              ? loop_rt_routes<false, true, true>(k,
+                                                                  remaining_k)
+                              : loop_rt_routes<false, true, false>(k,
+                                                                   remaining_k))
                        : (require_car_transport_
-                              ? loop_rt_routes<false, false, true>(k)
-                              : loop_rt_routes<false, false, false>(k)))
+                              ? loop_rt_routes<false, false, true>(k,
+                                                                   remaining_k)
+                              : loop_rt_routes<false, false, false>(
+                                    k, remaining_k)))
                 : (require_bike_transport_
                        ? (require_car_transport_
-                              ? loop_rt_routes<true, true, true>(k)
-                              : loop_rt_routes<true, true, false>(k))
+                              ? loop_rt_routes<true, true, true>(k, remaining_k)
+                              : loop_rt_routes<true, true, false>(k,
+                                                                  remaining_k))
                        : (require_car_transport_
-                              ? loop_rt_routes<true, false, true>(k)
-                              : loop_rt_routes<true, false, false>(k)));
+                              ? loop_rt_routes<true, false, true>(k,
+                                                                  remaining_k)
+                              : loop_rt_routes<true, false, false>(
+                                    k, remaining_k)));
       }
 
       if (!any_marked) {
@@ -275,10 +284,10 @@ struct raptor {
       std::swap(state_.prev_station_mark_, state_.station_mark_);
       utl::fill(state_.station_mark_.blocks_, 0U);
 
-      update_transfers(k);
+      update_transfers(k, remaining_k);
       update_intermodal_footpaths(k);
-      update_footpaths(k, prf_idx);
-      update_td_offsets(k, prf_idx);
+      update_footpaths(k, remaining_k, prf_idx);
+      update_td_offsets(k, remaining_k, prf_idx);
 
       trace_print_state_after_round();
     }
@@ -325,7 +334,7 @@ private:
   }
 
   template <bool WithClaszFilter, bool WithBikeFilter, bool WithCarFilter>
-  bool loop_routes(unsigned const k) {
+  bool loop_routes(unsigned const k, unsigned const remaining_k) {
     auto any_marked = false;
     state_.route_mark_.for_each_set_bit([&](auto const r_idx) {
       auto const r = route_idx_t{r_idx};
@@ -366,18 +375,19 @@ private:
 
       ++stats_.n_routes_visited_;
       trace("┊ ├k={} updating route {}\n", k, r);
-      any_marked |=
-          section_bike_filter
-              ? (section_car_filter ? update_route<true, true>(k, r)
-                                    : update_route<true, false>(k, r))
-              : (section_car_filter ? update_route<false, true>(k, r)
-                                    : update_route<false, false>(k, r));
+      any_marked |= section_bike_filter
+                        ? (section_car_filter
+                               ? update_route<true, true>(k, remaining_k, r)
+                               : update_route<true, false>(k, remaining_k, r))
+                        : (section_car_filter
+                               ? update_route<false, true>(k, remaining_k, r)
+                               : update_route<false, false>(k, remaining_k, r));
     });
     return any_marked;
   }
 
   template <bool WithClaszFilter, bool WithBikeFilter, bool WithCarFilter>
-  bool loop_rt_routes(unsigned const k) {
+  bool loop_rt_routes(unsigned const k, unsigned const remaining_k) {
     auto any_marked = false;
     state_.rt_transport_mark_.for_each_set_bit([&](auto const rt_t_idx) {
       auto const rt_t = rt_transport_idx_t{rt_t_idx};
@@ -421,16 +431,17 @@ private:
       trace("┊ ├k={} updating rt transport {}\n", k, rt_t);
       any_marked |=
           section_bike_filter
-              ? (section_car_filter ? update_rt_transport<true, true>(k, rt_t)
-                                    : update_rt_transport<true, false>(k, rt_t))
+              ? (section_car_filter
+                     ? update_rt_transport<true, true>(k, remaining_k, rt_t)
+                     : update_rt_transport<true, false>(k, remaining_k, rt_t))
               : (section_car_filter
-                     ? update_rt_transport<false, true>(k, rt_t)
-                     : update_rt_transport<false, false>(k, rt_t));
+                     ? update_rt_transport<false, true>(k, remaining_k, rt_t)
+                     : update_rt_transport<false, false>(k, remaining_k, rt_t));
     });
     return any_marked;
   }
 
-  void update_transfers(unsigned const k) {
+  void update_transfers(unsigned const k, unsigned const remaining_k) {
     state_.prev_station_mark_.for_each_set_bit([&](auto&& i) {
       for (auto v = 0U; v != Vias + 1; ++v) {
         auto const tmp_time = tmp_[i][v];
@@ -467,8 +478,12 @@ private:
 
         if (is_better(fp_target_time, best_[i][target_v]) &&
             is_better(fp_target_time, time_at_dest_[k])) {
-          if (lb_[i] == kUnreachable ||
-              !is_better(fp_target_time + dir(lb_[i]), time_at_dest_[k])) {
+          if (location_round_lb_[location_idx_t{i}][remaining_k] ==
+                  kUnreachable ||
+              !is_better(
+                  fp_target_time - transfer_time +
+                      dir(location_round_lb_[location_idx_t{i}][remaining_k]),
+                  time_at_dest_[k])) {
             ++stats_.fp_update_prevented_by_lower_bound_;
             return;
           }
@@ -485,7 +500,9 @@ private:
     });
   }
 
-  void update_footpaths(unsigned const k, profile_idx_t const prf_idx) {
+  void update_footpaths(unsigned const k,
+                        unsigned const remaining_k,
+                        profile_idx_t const prf_idx) {
     state_.prev_station_mark_.for_each_set_bit([&](std::uint64_t const i) {
       auto const l_idx = location_idx_t{i};
       if constexpr (Rt) {
@@ -525,17 +542,18 @@ private:
             stay += via_stops_[start_v].stay_;
           }
 
-          auto const fp_target_time = clamp(
-              tmp_time + dir(adjusted_transfer_time(transfer_time_settings_,
-                                                    fp.duration().count()) +
-                             stay.count()));
+          auto const transfer_time = dir(adjusted_transfer_time(
+              transfer_time_settings_, fp.duration().count()));
+          auto const fp_target_time =
+              clamp(tmp_time + transfer_time + dir(stay.count()));
 
           if (is_better(fp_target_time, best_[target][target_v]) &&
               is_better(fp_target_time, time_at_dest_[k])) {
-            auto const lower_bound = lb_[target];
-            if (lower_bound == kUnreachable ||
-                !is_better(fp_target_time + dir(lower_bound),
-                           time_at_dest_[k])) {
+            if (location_round_lb_[fp.target()][remaining_k] == kUnreachable ||
+                !is_better(
+                    fp_target_time - transfer_time +
+                        dir(location_round_lb_[fp.target()][remaining_k]),
+                    time_at_dest_[k])) {
               ++stats_.fp_update_prevented_by_lower_bound_;
               trace_upd(
                   "┊ ├k={} *** LB NO UPD: (from={}, tmp={}) --{}--> (to={}, "
@@ -579,7 +597,9 @@ private:
     });
   }
 
-  void update_td_offsets(unsigned const k, profile_idx_t const prf_idx) {
+  void update_td_offsets(unsigned const k,
+                         unsigned const remaining_k,
+                         profile_idx_t const prf_idx) {
     if constexpr (!Rt) {
       return;
     }
@@ -625,15 +645,17 @@ private:
             stay += via_stops_[start_v].stay_;
           }
 
+          auto const fp_time = dir(fp.duration().count());
           auto const fp_target_time =
-              clamp(tmp_time + dir(fp.duration().count() + stay.count()));
+              clamp(tmp_time + fp_time + dir(stay.count()));
 
           if (is_better(fp_target_time, best_[target][target_v]) &&
               is_better(fp_target_time, time_at_dest_[k])) {
-            auto const lower_bound = lb_[target];
-            if (lower_bound == kUnreachable ||
-                !is_better(fp_target_time + dir(lower_bound),
-                           time_at_dest_[k])) {
+            if (location_round_lb_[fp.target()][remaining_k] == kUnreachable ||
+                !is_better(
+                    fp_target_time - fp_time +
+                        dir(location_round_lb_[fp.target()][remaining_k]),
+                    time_at_dest_[k])) {
               ++stats_.fp_update_prevented_by_lower_bound_;
               trace_upd(
                   "┊ ├k={} *** LB NO TD FP UPD: (from={}, tmp={}) --{}--> "
@@ -788,7 +810,9 @@ private:
   }
 
   template <bool WithSectionBikeFilter, bool WithSectionCarFilter>
-  bool update_rt_transport(unsigned const k, rt_transport_idx_t const rt_t) {
+  bool update_rt_transport(unsigned const k,
+                           unsigned const remaining_k,
+                           rt_transport_idx_t const rt_t) {
     auto const stop_seq = rtt_->rt_transport_location_seq_[rt_t];
     auto et = std::array<bool, Vias + 1>{};
     auto v_offset = std::array<std::size_t, Vias + 1>{};
@@ -842,8 +866,12 @@ private:
                          tmp_[l_idx][target_v], best_[l_idx][target_v]);
 
             if (is_better(by_transport, time_at_dest_[k]) &&
-                lb_[l_idx] != kUnreachable &&
-                is_better(by_transport + dir(lb_[l_idx]), time_at_dest_[k])) {
+                location_round_lb_[stp.location_idx()][remaining_k] !=
+                    kUnreachable &&
+                is_better(
+                    by_transport + dir(location_round_lb_[stp.location_idx()]
+                                                         [remaining_k]),
+                    time_at_dest_[k])) {
               trace_upd(
                   "┊ │k={}    RT | name={}, dbg={}, time_by_transport={}, "
                   "BETTER THAN current_best={} => update, {} marking station "
@@ -867,7 +895,7 @@ private:
         }
       }
 
-      if (lb_[l_idx] == kUnreachable) {
+      if (location_round_lb_[stp.location_idx()][remaining_k] == kUnreachable) {
         break;
       }
 
@@ -891,7 +919,9 @@ private:
   }
 
   template <bool WithSectionBikeFilter, bool WithSectionCarFilter>
-  bool update_route(unsigned const k, route_idx_t const r) {
+  bool update_route(unsigned const k,
+                    unsigned const remaining_k,
+                    route_idx_t const r) {
     auto const stop_seq = tt_.route_location_seq_[r];
     bool any_marked = false;
 
@@ -979,8 +1009,12 @@ private:
           assert(by_transport != std::numeric_limits<delta_t>::min() &&
                  by_transport != std::numeric_limits<delta_t>::max());
           if (is_better(by_transport, time_at_dest_[k]) &&
-              lb_[l_idx] != kUnreachable &&
-              is_better(by_transport + dir(lb_[l_idx]), time_at_dest_[k])) {
+              location_round_lb_[stp.location_idx()][remaining_k] !=
+                  kUnreachable &&
+              is_better(
+                  by_transport +
+                      dir(location_round_lb_[stp.location_idx()][remaining_k]),
+                  time_at_dest_[k])) {
             trace_upd(
                 "┊ │k={} v={}->{}    name={}, dbg={}, time_by_transport={}, "
                 "BETTER THAN current_best={} => update, {} marking station "
@@ -1044,7 +1078,7 @@ private:
         continue;
       }
 
-      if (lb_[l_idx] == kUnreachable) {
+      if (location_round_lb_[stp.location_idx()][remaining_k] == kUnreachable) {
         break;
       }
 
@@ -1063,8 +1097,8 @@ private:
         if (prev_round_time != kInvalid &&
             is_better_or_eq(prev_round_time, et_time_at_stop)) {
           auto const [day, mam] = split(prev_round_time);
-          auto const new_et = get_earliest_transport(k, r, stop_idx, day, mam,
-                                                     stp.location_idx());
+          auto const new_et = get_earliest_transport(
+              k, remaining_k, r, stop_idx, day, mam, stp.location_idx());
           current_best[v] = get_best(current_best[v], best_[l_idx][target_v],
                                      tmp_[l_idx][target_v]);
           if (new_et.is_valid() &&
@@ -1088,6 +1122,7 @@ private:
   }
 
   transport get_earliest_transport(unsigned const k,
+                                   unsigned const remaining_k,
                                    route_idx_t const r,
                                    stop_idx_t const stop_idx,
                                    day_idx_t const day_at_stop,
@@ -1126,8 +1161,13 @@ private:
         auto const ev = *it;
         auto const ev_mam = ev.mam();
 
-        if (is_better_or_eq(time_at_dest_[k],
-                            to_delta(day, ev_mam) + dir(lb_[to_idx(l)]))) {
+        if (is_better_or_eq(
+                time_at_dest_[k],
+                to_delta(day, ev_mam) +
+                    dir(location_round_lb_[l][remaining_k] -
+                        adjusted_transfer_time(
+                            transfer_time_settings_,
+                            tt_.locations_.transfer_time_[l].count())))) {
           trace(
               "┊ │k={}      => name={}, dbg={}, day={}={}, best_mam={}, "
               "transport_mam={}, transport_time={} => TIME AT DEST {} IS "
@@ -1254,7 +1294,9 @@ private:
   std::array<bitvec, kMaxVias> const& is_via_;
   std::vector<std::uint16_t> const& dist_to_end_;
   hash_map<location_idx_t, std::vector<td_offset>> const& td_dist_to_end_;
-  std::vector<std::uint16_t> const& lb_;
+  vector_map<location_idx_t,
+             std::array<std::uint16_t, kMaxTransfers + 2U>> const&
+      location_round_lb_;
   std::vector<via_stop> const& via_stops_;
   std::array<delta_t, kMaxTransfers + 2> time_at_dest_;
   day_idx_t base_;

--- a/include/nigiri/routing/search.h
+++ b/include/nigiri/routing/search.h
@@ -23,7 +23,6 @@
 #include "nigiri/routing/pareto_set.h"
 #include "nigiri/routing/query.h"
 #include "nigiri/routing/raptor/debug.h"
-#include "nigiri/routing/raptor/raptor_state.h"
 #include "nigiri/routing/start_times.h"
 #include "nigiri/rt/rt_timetable.h"
 #include "nigiri/timetable.h"
@@ -130,11 +129,14 @@ struct search {
       stats_.lb_time_ = static_cast<std::uint64_t>(UTL_TIMING_MS(lb));
 
       if (q_.prf_idx_ == kDefaultProfile) {
-        auto rs = raptor_state{};
+        auto station_mark = bitvec{};
+        auto prev_station_mark = bitvec{};
+        auto is_start = bitvec{};
         auto location_round_lb =
             vector_map<location_idx_t,
                        std::array<std::uint16_t, kMaxTransfers + 2U>>{};
-        lb_raptor<SearchDir>(tt_, q_, rs, location_round_lb);
+        lb_raptor<SearchDir>(tt_, q_, station_mark, prev_station_mark, is_start,
+                             location_round_lb);
       }
 
 #if defined(NIGIRI_TRACING)

--- a/include/nigiri/routing/search.h
+++ b/include/nigiri/routing/search.h
@@ -18,10 +18,12 @@
 #include "nigiri/routing/get_fastest_direct.h"
 #include "nigiri/routing/interval_estimate.h"
 #include "nigiri/routing/journey.h"
+#include "nigiri/routing/lb_raptor.h"
 #include "nigiri/routing/limits.h"
 #include "nigiri/routing/pareto_set.h"
 #include "nigiri/routing/query.h"
 #include "nigiri/routing/raptor/debug.h"
+#include "nigiri/routing/raptor/raptor_state.h"
 #include "nigiri/routing/start_times.h"
 #include "nigiri/rt/rt_timetable.h"
 #include "nigiri/timetable.h"
@@ -126,6 +128,14 @@ struct search {
           state_.travel_time_lower_bound_);
       UTL_STOP_TIMING(lb);
       stats_.lb_time_ = static_cast<std::uint64_t>(UTL_TIMING_MS(lb));
+
+      if (q_.prf_idx_ == kDefaultProfile) {
+        auto rs = raptor_state{};
+        auto location_round_lb =
+            vector_map<location_idx_t,
+                       std::array<std::uint16_t, kMaxTransfers + 2U>>{};
+        lb_raptor<SearchDir>(tt_, q_, rs, location_round_lb);
+      }
 
 #if defined(NIGIRI_TRACING)
       for (auto const& o : q_.start_) {

--- a/include/nigiri/routing/search.h
+++ b/include/nigiri/routing/search.h
@@ -38,7 +38,7 @@ struct search_state {
   search_state& operator=(search_state&&) = default;
   ~search_state() = default;
 
-  std::vector<std::uint16_t> travel_time_lower_bound_;
+  lb_raptor_state lb_raptor_state_;
   bitvec is_destination_;
   std::array<bitvec, kMaxVias> is_via_;
   std::vector<std::uint16_t> dist_to_dest_;
@@ -114,30 +114,13 @@ struct search {
       auto lb_span = get_otel_tracer()->StartSpan("lower bounds");
       auto lb_scope = opentelemetry::trace::Scope{lb_span};
       UTL_START_TIMING(lb);
-      dijkstra(
-          tt_, q_,
-          (kFwd ? tt_.fwd_search_lb_graph_[q_.prf_idx_]
-                : tt_.bwd_search_lb_graph_[q_.prf_idx_]),
-          (rtt_ == nullptr ? nullptr
-                           : &(kFwd ? rtt_->fwd_search_lb_graph_has_edges_
-                                    : rtt_->bwd_search_lb_graph_has_edges_)),
-          (rtt_ == nullptr ? nullptr
-                           : &(kFwd ? rtt_->fwd_search_lb_graph_
-                                    : rtt_->bwd_search_lb_graph_)),
-          state_.travel_time_lower_bound_);
+      if (q_.prf_idx_ == kDefaultProfile) {
+        lb_raptor<SearchDir>(tt_, q_, state_.lb_raptor_state_);
+      } else {
+        state_.lb_raptor_state_.zeroize();
+      }
       UTL_STOP_TIMING(lb);
       stats_.lb_time_ = static_cast<std::uint64_t>(UTL_TIMING_MS(lb));
-
-      if (q_.prf_idx_ == kDefaultProfile) {
-        auto station_mark = bitvec{};
-        auto prev_station_mark = bitvec{};
-        auto is_start = bitvec{};
-        auto location_round_lb =
-            vector_map<location_idx_t,
-                       std::array<std::uint16_t, kMaxTransfers + 2U>>{};
-        lb_raptor<SearchDir>(tt_, q_, station_mark, prev_station_mark, is_start,
-                             location_round_lb);
-      }
 
 #if defined(NIGIRI_TRACING)
       for (auto const& o : q_.start_) {
@@ -163,7 +146,7 @@ struct search {
         state_.is_via_,
         state_.dist_to_dest_,
         q_.td_dest_,
-        state_.travel_time_lower_bound_,
+        state_.lb_raptor_state_.location_round_lb_,
         q_.via_stops_,
         day_idx_t{
             std::chrono::duration_cast<date::days>(

--- a/include/nigiri/routing/tb/query_engine.h
+++ b/include/nigiri/routing/tb/query_engine.h
@@ -87,7 +87,9 @@ struct query_engine {
                std::array<bitvec, kMaxVias> const&,
                std::vector<std::uint16_t> const& dist_to_dest,
                hash_map<location_idx_t, std::vector<td_offset>> const&,
-               std::vector<std::uint16_t> const& lb,
+               vector_map<location_idx_t,
+                          std::array<std::uint16_t, kMaxTransfers + 2U>> const&
+                   location_round_lb,
                std::vector<via_stop> const&,
                day_idx_t base,
                clasz_mask_t,
@@ -120,7 +122,7 @@ struct query_engine {
 
 private:
   void seg_dest(std::uint8_t k, queue_idx_t);
-  void seg_prune(std::uint8_t k, queue_entry&);
+  void seg_prune(std::uint8_t k, unsigned remaining_k, queue_entry&);
   void seg_transfers(queue_idx_t, std::uint8_t k);
 
   segment_info seg(segment_idx_t, queue_entry const&) const;
@@ -130,7 +132,9 @@ private:
   query_state& state_;
   bitvec const& is_dest_;
   std::vector<std::uint16_t> const& dist_to_dest_;
-  std::vector<std::uint16_t> const& lb_;
+  vector_map<location_idx_t,
+             std::array<std::uint16_t, kMaxTransfers + 2U>> const&
+      location_round_lb_;
   day_idx_t base_;
   query_stats stats_;
 };

--- a/include/nigiri/timetable.h
+++ b/include/nigiri/timetable.h
@@ -412,6 +412,10 @@ struct timetable {
   std::array<vecvec<location_idx_t, footpath>, kNProfiles> fwd_search_lb_graph_;
   std::array<vecvec<location_idx_t, footpath>, kNProfiles> bwd_search_lb_graph_;
 
+  // lower bound adjacency
+  std::array<vecvec<location_idx_t, lb_neighbor>, kNProfiles> fwd_lb_adjacency_;
+  std::array<vecvec<location_idx_t, lb_neighbor>, kNProfiles> bwd_lb_adjacency_;
+
   // profile name -> profile_idx_t
   hash_map<string, profile_idx_t> profiles_;
 

--- a/include/nigiri/types.h
+++ b/include/nigiri/types.h
@@ -701,7 +701,8 @@ struct booking_rule {
 
 struct lb_neighbor {
   location_idx_t l_;
-  std::uint16_t dist_;
+  std::uint16_t pt_duration_;
+  std::uint16_t transfer_duration_;
 };
 
 }  // namespace nigiri

--- a/include/nigiri/types.h
+++ b/include/nigiri/types.h
@@ -699,6 +699,11 @@ struct booking_rule {
   translation_idx_t booking_url_;
 };
 
+struct lb_neighbor {
+  location_idx_t n_;
+  std::uint16_t lb_;
+};
+
 }  // namespace nigiri
 
 template <>

--- a/include/nigiri/types.h
+++ b/include/nigiri/types.h
@@ -700,8 +700,8 @@ struct booking_rule {
 };
 
 struct lb_neighbor {
-  location_idx_t n_;
-  std::uint16_t lb_;
+  location_idx_t l_;
+  std::uint16_t dist_;
 };
 
 }  // namespace nigiri

--- a/src/loader/build_lb_adjacency.cc
+++ b/src/loader/build_lb_adjacency.cc
@@ -10,6 +10,8 @@
 namespace nigiri::loader {
 
 void build_lb_adjacency(timetable& tt, profile_idx_t const prf_idx) {
+  auto const timer = scoped_timer{"loader.build_lb_adjacency"};
+
   struct adjacencies {
     hash_map<location_idx_t, std::uint16_t> in_;
     hash_map<location_idx_t, std::uint16_t> out_;

--- a/src/loader/build_lb_adjacency.cc
+++ b/src/loader/build_lb_adjacency.cc
@@ -31,13 +31,15 @@ void build_lb_adjacency(timetable& tt, profile_idx_t const prf_idx) {
 
       auto const location_seq = tt.route_location_seq_[r];
       for (auto const [i, x] : utl::enumerate(location_seq)) {
-        auto const is = stop{x};
-        if (l != is.location_idx()) {
+        auto const i_stop = stop{x};
+        auto const i_stop_idx = static_cast<stop_idx_t>(i);
+        if (l != i_stop.location_idx()) {
           continue;
         }
 
         for (auto const [j, y] : utl::enumerate(location_seq)) {
-          auto const js = stop{y};
+          auto const j_stop = stop{y};
+          auto const j_stop_idx = static_cast<stop_idx_t>(j);
           for (auto const t : tt.route_transport_ranges_[r]) {
             auto const min = [&](auto& hm, auto const n, auto const d) {
               auto& v = utl::get_or_create(hm, n, [] {
@@ -46,21 +48,21 @@ void build_lb_adjacency(timetable& tt, profile_idx_t const prf_idx) {
               v = std::min(v, d);
             };
 
-            if (j < i && js.in_allowed() &&
-                is.out_allowed()) {  // TODO wheelchair profile
-              min(a.in_, js.location_idx(),
+            if (j < i && j_stop.in_allowed() &&
+                i_stop.out_allowed()) {  // TODO wheelchair profile
+              min(a.in_, j_stop.location_idx(),
                   static_cast<std::uint16_t>(
-                      (tt.event_mam(t, i, event_type::kArr) -
-                       tt.event_mam(t, j, event_type::kDep))
+                      (tt.event_mam(t, i_stop_idx, event_type::kArr) -
+                       tt.event_mam(t, j_stop_idx, event_type::kDep))
                           .count()));
             }
 
-            if (i < j && is.in_allowed() &&
-                js.out_allowed()) {  // TODO wheelchair profile
-              min(a.out_, js.location_idx(),
+            if (i < j && i_stop.in_allowed() &&
+                j_stop.out_allowed()) {  // TODO wheelchair profile
+              min(a.out_, j_stop.location_idx(),
                   static_cast<std::uint16_t>(
-                      (tt.event_mam(t, j, event_type::kArr) -
-                       tt.event_mam(t, i, event_type::kDep))
+                      (tt.event_mam(t, j_stop_idx, event_type::kArr) -
+                       tt.event_mam(t, i_stop_idx, event_type::kDep))
                           .count()));
             }
           }
@@ -80,23 +82,13 @@ void build_lb_adjacency(timetable& tt, profile_idx_t const prf_idx) {
         a.out_.clear();
         auto ns = lb_neighbors{};
 
-        if (tt.locations_.parents_[l] != location_idx_t::invalid()) {
-          return ns;
-        }
-
-        for (auto const c : tt.locations_.children_[l]) {
-          explore_routes(c, a);
-          for (auto const cc : tt.locations_.children_[c]) {
-            explore_routes(cc, a);
-          }
-        }
         explore_routes(l, a);
 
-        for (auto const& [k, v] : a.in_) {
-          ns.in_.emplace_back(k, v);
+        for (auto const& [n, dist] : a.in_) {
+          ns.in_.emplace_back(n, dist);
         }
-        for (auto const& [k, v] : a.out_) {
-          ns.out_.emplace_back(k, v);
+        for (auto const& [n, dist] : a.out_) {
+          ns.out_.emplace_back(n, dist);
         }
 
         return ns;

--- a/src/loader/build_lb_adjacency.cc
+++ b/src/loader/build_lb_adjacency.cc
@@ -1,0 +1,85 @@
+#include "nigiri/loader/build_lb_adjacency.h"
+
+#include <ranges>
+
+#include "utl/enumerate.h"
+#include "utl/get_or_create.h"
+#include "utl/parallel_for.h"
+#include "utl/progress_tracker.h"
+
+namespace nigiri::loader {
+
+void build_lb_adjacency(timetable& tt, profile_idx_t const prf_idx) {
+  struct adjacencies {
+    hash_map<location_idx_t, std::uint16_t> in_;
+    hash_map<location_idx_t, std::uint16_t> out_;
+  };
+
+  struct lb_neighbors {
+    std::vector<lb_neighbor> in_;
+    std::vector<lb_neighbor> out_;
+  };
+
+  auto const explore_routes = [&](location_idx_t const l, adjacencies& a) {
+    for (auto const r : tt.location_routes_[l]) {
+      if ((prf_idx == kCarProfile && !tt.has_car_transport(r)) ||
+          (prf_idx == kBikeProfile && !tt.has_bike_transport(r))) {
+        continue;
+      }
+
+      auto const location_seq = tt.route_location_seq_[r];
+      for (auto const [i, x] : utl::enumerate(location_seq)) {
+        auto const is = stop{x};
+        if (l != is.location_idx()) {
+          continue;
+        }
+
+        for (auto const [j, y] : utl::enumerate(location_seq)) {
+          auto const js = stop{y};
+          for (auto const t : tt.route_transport_ranges_[r]) {
+            if (j < i && js.in_allowed() && is.out_allowed()) {
+              auto const dist = static_cast<std::uint16_t>(
+                  (tt.event_mam(t, i, event_type::kArr) -
+                   tt.event_mam(t, j, event_type::kDep))
+                      .count());
+              a.in_[js.location_idx()] = std::min(
+                  utl::get_or_create(a.in_, js.location_idx(), []), dist);
+            }
+
+            if (i < j && is.in_allowed() && js.out_allowed()) {
+              auto const dist = static_cast<std::uint16_t>(
+                  (tt.event_mam(t, j, event_type::kArr) -
+                   tt.event_mam(t, i, event_type::kDep))
+                      .count());
+            }
+          }
+        }
+      }
+    }
+  };
+
+  auto const pt = utl::get_active_progress_tracker();
+  pt->status("Compute lower bound adjacencies").in_high(tt.n_locations());
+  utl::parallel_ordered_collect_threadlocal<adjacencies>(
+      tt.n_locations(),
+
+      // parallel
+      [&](adjacencies& a, std::size_t const i) {
+        auto const l = location_idx_t{i};
+        a.in_.clear();
+        a.out_.clear();
+        auto ns = lb_neighbors{};
+
+        if (tt.locations_.parents_[l] != location_idx_t::invalid()) {
+          return ns;
+        }
+        return ns;
+      },
+
+      // ordered
+      [&](std::size_t const i, lb_neighbors ns) {}, pt->update_fn()
+
+  );
+}
+
+}  // namespace nigiri::loader

--- a/src/loader/build_lb_adjacency.cc
+++ b/src/loader/build_lb_adjacency.cc
@@ -37,20 +37,29 @@ void build_lb_adjacency(timetable& tt, profile_idx_t const prf_idx) {
         for (auto const [j, y] : utl::enumerate(location_seq)) {
           auto const js = stop{y};
           for (auto const t : tt.route_transport_ranges_[r]) {
-            if (j < i && js.in_allowed() && is.out_allowed()) {
-              auto const dist = static_cast<std::uint16_t>(
-                  (tt.event_mam(t, i, event_type::kArr) -
-                   tt.event_mam(t, j, event_type::kDep))
-                      .count());
-              a.in_[js.location_idx()] = std::min(
-                  utl::get_or_create(a.in_, js.location_idx(), []), dist);
+            auto const min = [&](auto& hm, auto const n, auto const d) {
+              auto& v = utl::get_or_create(hm, n, [] {
+                return std::numeric_limits<std::uint16_t>::max();
+              });
+              v = std::min(v, d);
+            };
+
+            if (j < i && js.in_allowed() &&
+                is.out_allowed()) {  // TODO wheelchair profile
+              min(a.in_, js.location_idx(),
+                  static_cast<std::uint16_t>(
+                      (tt.event_mam(t, i, event_type::kArr) -
+                       tt.event_mam(t, j, event_type::kDep))
+                          .count()));
             }
 
-            if (i < j && is.in_allowed() && js.out_allowed()) {
-              auto const dist = static_cast<std::uint16_t>(
-                  (tt.event_mam(t, j, event_type::kArr) -
-                   tt.event_mam(t, i, event_type::kDep))
-                      .count());
+            if (i < j && is.in_allowed() &&
+                js.out_allowed()) {  // TODO wheelchair profile
+              min(a.out_, js.location_idx(),
+                  static_cast<std::uint16_t>(
+                      (tt.event_mam(t, j, event_type::kArr) -
+                       tt.event_mam(t, i, event_type::kDep))
+                          .count()));
             }
           }
         }

--- a/src/loader/build_lb_adjacency.cc
+++ b/src/loader/build_lb_adjacency.cc
@@ -82,11 +82,31 @@ void build_lb_adjacency(timetable& tt, profile_idx_t const prf_idx) {
         if (tt.locations_.parents_[l] != location_idx_t::invalid()) {
           return ns;
         }
+
+        for (auto const c : tt.locations_.children_[l]) {
+          explore_routes(c, a);
+          for (auto const cc : tt.locations_.children_[c]) {
+            explore_routes(cc, a);
+          }
+        }
+        explore_routes(l, a);
+
+        for (auto const [k, v] : a.in_) {
+          ns.in_.emplace_back(k, v);
+        }
+        for (auto const [k, v] : a.out_) {
+          ns.out_.emplace_back(k, v);
+        }
+
         return ns;
       },
 
       // ordered
-      [&](std::size_t const i, lb_neighbors ns) {}, pt->update_fn()
+      [&](std::size_t, lb_neighbors&& ns) {
+        tt.fwd_lb_adjacency_[prf_idx].emplace_back(ns.out_);
+        tt.bwd_lb_adjacency_[prf_idx].emplace_back(ns.in_);
+      },
+      pt->update_fn()
 
   );
 }

--- a/src/loader/build_lb_adjacency.cc
+++ b/src/loader/build_lb_adjacency.cc
@@ -71,7 +71,6 @@ void build_lb_adjacency(timetable& tt, profile_idx_t const prf_idx) {
   pt->status("Compute lower bound adjacencies").in_high(tt.n_locations());
   utl::parallel_ordered_collect_threadlocal<adjacencies>(
       tt.n_locations(),
-
       // parallel
       [&](adjacencies& a, std::size_t const i) {
         auto const l = location_idx_t{i};
@@ -100,15 +99,12 @@ void build_lb_adjacency(timetable& tt, profile_idx_t const prf_idx) {
 
         return ns;
       },
-
       // ordered
       [&](std::size_t, lb_neighbors&& ns) {
-        tt.fwd_lb_adjacency_[prf_idx].emplace_back(ns.out_);
-        tt.bwd_lb_adjacency_[prf_idx].emplace_back(ns.in_);
+        tt.fwd_lb_adjacency_[prf_idx].emplace_back(ns.in_);
+        tt.bwd_lb_adjacency_[prf_idx].emplace_back(ns.out_);
       },
-      pt->update_fn()
-
-  );
+      pt->update_fn());
 }
 
 }  // namespace nigiri::loader

--- a/src/loader/build_lb_adjacency.cc
+++ b/src/loader/build_lb_adjacency.cc
@@ -12,9 +12,20 @@ namespace nigiri::loader {
 void build_lb_adjacency(timetable& tt, profile_idx_t const prf_idx) {
   auto const timer = scoped_timer{"loader.build_lb_adjacency"};
 
+  struct durations {
+    bool operator<(durations const o) const {
+      return o.pt_duration_ == std::numeric_limits<std::uint16_t>::max() ||
+             pt_duration_ + transfer_duration_ <
+                 o.pt_duration_ + o.transfer_duration_;
+    }
+
+    std::uint16_t pt_duration_{std::numeric_limits<std::uint16_t>::max()};
+    std::uint16_t transfer_duration_{std::numeric_limits<std::uint16_t>::max()};
+  };
+
   struct adjacencies {
-    hash_map<location_idx_t, std::uint16_t> in_;
-    hash_map<location_idx_t, std::uint16_t> out_;
+    hash_map<location_idx_t, durations> in_;
+    hash_map<location_idx_t, durations> out_;
   };
 
   struct lb_neighbors {
@@ -41,29 +52,46 @@ void build_lb_adjacency(timetable& tt, profile_idx_t const prf_idx) {
           auto const j_stop = stop{y};
           auto const j_stop_idx = static_cast<stop_idx_t>(j);
           for (auto const t : tt.route_transport_ranges_[r]) {
-            auto const min = [&](auto& hm, auto const n, auto const d) {
-              auto& v = utl::get_or_create(hm, n, [] {
-                return std::numeric_limits<std::uint16_t>::max();
-              });
-              v = std::min(v, d);
+            auto const min = [&](auto& hm, auto const n, durations const d) {
+              auto& v = utl::get_or_create(hm, n, [] { return durations{}; });
+              if (d < v) {
+                v = d;
+                return true;
+              }
+              return false;
             };
 
             if (j < i && j_stop.in_allowed() &&
                 i_stop.out_allowed()) {  // TODO wheelchair profile
-              min(a.in_, j_stop.location_idx(),
-                  static_cast<std::uint16_t>(
-                      (tt.event_mam(t, i_stop_idx, event_type::kArr) -
-                       tt.event_mam(t, j_stop_idx, event_type::kDep))
-                          .count()));
+              auto const pt_duration = static_cast<std::uint16_t>(
+                  (tt.event_mam(t, i_stop_idx, event_type::kArr) -
+                   tt.event_mam(t, j_stop_idx, event_type::kDep))
+                      .count());
+              if (min(a.in_, j_stop.location_idx(),
+                      {pt_duration,
+                       tt.locations_.transfer_time_[j_stop.location_idx()]
+                           .count()})) {
+                for (auto const fp :
+                     tt.locations_
+                         .footpaths_in_[prf_idx][j_stop.location_idx()]) {
+                  min(a.in_, fp.target(),
+                      {pt_duration,
+                       static_cast<std::uint16_t>(fp.duration().count())});
+                }
+              }
             }
 
             if (i < j && i_stop.in_allowed() &&
                 j_stop.out_allowed()) {  // TODO wheelchair profile
-              min(a.out_, j_stop.location_idx(),
-                  static_cast<std::uint16_t>(
+              auto const pt_duration = static_cast<std::uint16_t>(
                       (tt.event_mam(t, j_stop_idx, event_type::kArr) -
                        tt.event_mam(t, i_stop_idx, event_type::kDep))
-                          .count()));
+                          .count());
+              if (min(a.out_, j_stop.location_idx(), {pt_duration, tt.locations_.transfer_time_[j_stop.location_idx()]
+                           .count()})) {
+                for (auto const fp : tt.locations_. )
+              }
+              ;
             }
           }
         }

--- a/src/loader/build_lb_adjacency.cc
+++ b/src/loader/build_lb_adjacency.cc
@@ -90,10 +90,10 @@ void build_lb_adjacency(timetable& tt, profile_idx_t const prf_idx) {
         }
         explore_routes(l, a);
 
-        for (auto const [k, v] : a.in_) {
+        for (auto const& [k, v] : a.in_) {
           ns.in_.emplace_back(k, v);
         }
-        for (auto const [k, v] : a.out_) {
+        for (auto const& [k, v] : a.out_) {
           ns.out_.emplace_back(k, v);
         }
 

--- a/src/loader/build_lb_adjacency.cc
+++ b/src/loader/build_lb_adjacency.cc
@@ -51,6 +51,10 @@ void build_lb_adjacency(timetable& tt, profile_idx_t const prf_idx) {
         for (auto const [j, y] : utl::enumerate(location_seq)) {
           auto const j_stop = stop{y};
           auto const j_stop_idx = static_cast<stop_idx_t>(j);
+          if (l == j_stop.location_idx()) {
+            continue;
+          }
+
           for (auto const t : tt.route_transport_ranges_[r]) {
             auto const min = [&](auto& hm, auto const n, durations const d) {
               auto& v = utl::get_or_create(hm, n, [] { return durations{}; });
@@ -84,14 +88,21 @@ void build_lb_adjacency(timetable& tt, profile_idx_t const prf_idx) {
             if (i < j && i_stop.in_allowed() &&
                 j_stop.out_allowed()) {  // TODO wheelchair profile
               auto const pt_duration = static_cast<std::uint16_t>(
-                      (tt.event_mam(t, j_stop_idx, event_type::kArr) -
-                       tt.event_mam(t, i_stop_idx, event_type::kDep))
-                          .count());
-              if (min(a.out_, j_stop.location_idx(), {pt_duration, tt.locations_.transfer_time_[j_stop.location_idx()]
+                  (tt.event_mam(t, j_stop_idx, event_type::kArr) -
+                   tt.event_mam(t, i_stop_idx, event_type::kDep))
+                      .count());
+              if (min(a.out_, j_stop.location_idx(),
+                      {pt_duration,
+                       tt.locations_.transfer_time_[j_stop.location_idx()]
                            .count()})) {
-                for (auto const fp : tt.locations_. )
+                for (auto const fp :
+                     tt.locations_
+                         .footpaths_out_[prf_idx][j_stop.location_idx()]) {
+                  min(a.out_, fp.target(),
+                      {pt_duration,
+                       static_cast<std::uint16_t>(fp.duration().count())});
+                }
               }
-              ;
             }
           }
         }
@@ -112,11 +123,11 @@ void build_lb_adjacency(timetable& tt, profile_idx_t const prf_idx) {
 
         explore_routes(l, a);
 
-        for (auto const& [n, dist] : a.in_) {
-          ns.in_.emplace_back(n, dist);
+        for (auto const& [n, d] : a.in_) {
+          ns.in_.emplace_back(n, d.pt_duration_, d.transfer_duration_);
         }
-        for (auto const& [n, dist] : a.out_) {
-          ns.out_.emplace_back(n, dist);
+        for (auto const& [n, d] : a.out_) {
+          ns.out_.emplace_back(n, d.pt_duration_, d.transfer_duration_);
         }
 
         return ns;

--- a/src/loader/init_finish.cc
+++ b/src/loader/init_finish.cc
@@ -7,6 +7,7 @@
 #include "geo/box.h"
 
 #include "nigiri/loader/build_footpaths.h"
+#include "nigiri/loader/build_lb_adjacency.h"
 #include "nigiri/loader/build_lb_graph.h"
 #include "nigiri/loader/register.h"
 #include "nigiri/flex.h"
@@ -186,6 +187,7 @@ void finalize(timetable& tt, finalize_options const opt) {
   build_footpaths(tt, opt);
   build_lb_graph<direction::kForward>(tt, kDefaultProfile);
   build_lb_graph<direction::kBackward>(tt, kDefaultProfile);
+  build_lb_adjacency(tt, kDefaultProfile);
   build_location_tree(tt);
   assign_stops_to_flex_areas(tt);
   assign_importance(tt);

--- a/src/routing/lb_raptor.cc
+++ b/src/routing/lb_raptor.cc
@@ -1,6 +1,8 @@
 #include "nigiri/routing/lb_raptor.h"
 
+#include "utl/enumerate.h"
 #include "utl/get_or_create.h"
+#include "utl/zip.h"
 
 #include "nigiri/for_each_meta.h"
 #include "nigiri/routing/query.h"
@@ -60,7 +62,7 @@ void lb_raptor(
   }
 
   // run
-  for (auto k = 1U; k != kMaxTransfers + 2U; ++k) {
+  for (auto const k : interval{1U, kMaxTransfers + 2U}) {
     std::swap(state.prev_station_mark_, state.station_mark_);
     utl::fill(state.station_mark_.blocks_, 0U);
 
@@ -77,5 +79,17 @@ void lb_raptor(
       return;
     }
   }
+
+  // propagate lb to children
+  for (auto const l :
+       interval{location_idx_t{0}, location_idx_t{tt.n_locations()}}) {
+    for (auto const c : tt.locations_.children_[l]) {
+      for (auto [plb, clb] :
+           utl::zip(location_round_lb[l], location_round_lb[c])) {
+        clb = std::min(plb, clb);
+      }
+    }
+  }
 }
+
 }  // namespace nigiri::routing

--- a/src/routing/lb_raptor.cc
+++ b/src/routing/lb_raptor.cc
@@ -58,12 +58,29 @@ void lb_raptor(
       state.station_mark_.set(to_idx(meta), true);
     });
   }
+  auto const& footpaths = SearchDir == direction::kForward
+                              ? tt.locations_.footpaths_in_[q.prf_idx_]
+                              : tt.locations_.footpaths_out_[q.prf_idx_];
 
   // run
   for (auto const k : interval{1U, kMaxTransfers + 2U}) {
-    // TODO expand footpaths from/to marked stations, they are reached in k-1
-
     std::swap(state.prev_station_mark_, state.station_mark_);
+    utl::fill(state.station_mark_.blocks_, 0U);
+
+    state.prev_station_mark_.for_each_set_bit([&](std::uint64_t const i) {
+      auto const l = location_idx_t{i};
+      for (auto const& fp : footpaths[l]) {
+        auto const new_lb = static_cast<std::uint16_t>(
+            location_round_lb[l][k - 1] + fp.duration().count());
+        if (new_lb < location_round_lb[fp.target()][k - 1]) {
+          std::fill(begin(location_round_lb[fp.target()]) + k - 1,
+                    end(location_round_lb[fp.target()]), new_lb);
+          state.station_mark_.set(to_idx(fp.target()), true);
+        }
+      }
+    });
+
+    state.prev_station_mark_ |= state.station_mark_;
     utl::fill(state.station_mark_.blocks_, 0U);
 
     auto any_marked = false;

--- a/src/routing/lb_raptor.cc
+++ b/src/routing/lb_raptor.cc
@@ -42,14 +42,14 @@ void lb_raptor(
   };
   for (auto const& o : q.destination_) {
     for_each_meta(
-        tt, q.dest_match_mode_, o.target_,
-        [&](location_idx_t const l) { update_min(l, o.duration_.count()); });
+        tt, q.dest_match_mode_, o.target(),
+        [&](location_idx_t const l) { update_min(l, o.duration().count()); });
   }
   for (auto const& [l, tds] : q.td_dest_) {
     for (auto const& td : tds) {
-      if (td.duration_ != footpath::kMaxDuration &&
-          td.duration_ < q.max_travel_time_) {
-        update_min(l, td.duration_.count());
+      if (td.duration() != footpath::kMaxDuration &&
+          td.duration() < q.max_travel_time_) {
+        update_min(l, td.duration().count());
       }
     }
   }
@@ -68,15 +68,31 @@ void lb_raptor(
 
     auto any_marked = false;
     state.prev_station_mark_.for_each_set_bit([&](std::uint64_t const i) {
-      any_marked = true;
-      // follow lb graph and/or rt lb graph from this station
-      // for each edge
-      // check if time of this station + edge duration leads to an improvement
-      // for the next round if yes write improved time to location_round_lb mark
-      // the station with the improved time for the next round
+      auto const l = location_idx_t{i};
+
+      auto const expand = [&](footpath const& e) {
+        auto const new_lb = static_cast<std::uint16_t>(location_round_lb[l][k] +
+                                                       e.duration().count());
+        if (new_lb < location_round_lb[e.target()][k + 1U]) {
+          any_marked = true;
+          std::fill(begin(location_round_lb[e.target()]) + k + 1U,
+                    end(location_round_lb[e.target()]), new_lb);
+          state.station_mark_.set(to_idx(e.target()), true);
+        }
+      };
+
+      for (auto const& e : lb_graph[l]) {
+        expand(e);
+      }
+
+      if (has_rt != nullptr && has_rt->test(l)) {
+        for (auto const& e : (*rt_lb_graph)[l]) {
+          expand(e);
+        }
+      }
     });
     if (!any_marked) {
-      return;
+      break;
     }
   }
 

--- a/src/routing/lb_raptor.cc
+++ b/src/routing/lb_raptor.cc
@@ -1,0 +1,14 @@
+#include "nigiri/routing/lb_raptor.h"
+
+namespace nigiri::routing {
+
+void lb_raptor(
+    timetable const& tt,
+    query const& q,
+    vecvec<location_idx_t, footpath> const& lb_graph,
+    bitvec_map<location_idx_t> const* has_rt,
+    vecvec<location_idx_t, footpath> const* rt_lb_graph,
+    vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2>>&
+        location_round_lb) {}
+
+}  // namespace nigiri::routing

--- a/src/routing/lb_raptor.cc
+++ b/src/routing/lb_raptor.cc
@@ -16,9 +16,6 @@ void lb_raptor(timetable const& tt, query const& q, lb_raptor_state& state) {
   auto const& adjacency =
       (SearchDir == direction::kForward ? tt.fwd_lb_adjacency_
                                         : tt.bwd_lb_adjacency_)[q.prf_idx_];
-  auto const& footpaths = (SearchDir == direction::kForward
-                               ? tt.locations_.footpaths_in_
-                               : tt.locations_.footpaths_out_)[q.prf_idx_];
 
   state.resize(tt.n_locations());
   state.clear();
@@ -69,39 +66,22 @@ void lb_raptor(timetable const& tt, query const& q, lb_raptor_state& state) {
       auto const l = location_idx_t{i};
 
       auto const visit = [&](lb_neighbor const n) {
-        auto const lb = static_cast<std::uint16_t>(
+        auto const lb_pt = static_cast<std::uint16_t>(
             state.location_round_lb_[l][k - 1U] + n.pt_duration_);
 
         if (state.is_start_.test(to_idx(n.l_)) &&
-            lb < state.location_round_lb_[n.l_][k]) [[unlikely]] {
+            lb_pt < state.location_round_lb_[n.l_][k]) [[unlikely]] {
           std::fill(begin(state.location_round_lb_[n.l_]) + k,
-                    end(state.location_round_lb_[n.l_]), lb);
-          return;
-        }
-
-        auto const lb_transfer = static_cast<std::uint16_t>(
-            lb +
-            adjusted_transfer_time(q.transfer_time_settings_,
-                                   tt.locations_.transfer_time_[n.l_].count()));
-        if (lb_transfer < state.location_round_lb_[n.l_][k]) {
-          std::fill(begin(state.location_round_lb_[n.l_]) + k,
-                    end(state.location_round_lb_[n.l_]), lb_transfer);
-          state.station_mark_.set(to_idx(n.l_), true);
-          any_marked = true;
-
-          for (auto const fp : footpaths[n.l_]) {
-            if (state.is_start_.test(to_idx(fp.target()))) [[unlikely]] {
-              continue;
-            }
-
-            auto const lb_fp = static_cast<std::uint16_t>(
-                lb + adjusted_transfer_time(q.transfer_time_settings_,
-                                            fp.duration().count()));
-            if (lb_fp < state.location_round_lb_[fp.target()][k]) {
-              std::fill(begin(state.location_round_lb_[fp.target()]) + k,
-                        end(state.location_round_lb_[fp.target()]), lb_fp);
-              state.station_mark_.set(to_idx(fp.target()), true);
-            }
+                    end(state.location_round_lb_[n.l_]), lb_pt);
+        } else {
+          auto const lb_transfer = static_cast<std::uint16_t>(
+              lb_pt + adjusted_transfer_time(q.transfer_time_settings_,
+                                             n.transfer_duration_));
+          if (lb_transfer < state.location_round_lb_[n.l_][k]) {
+            std::fill(begin(state.location_round_lb_[n.l_]) + k,
+                      end(state.location_round_lb_[n.l_]), lb_transfer);
+            state.station_mark_.set(to_idx(n.l_), true);
+            any_marked = true;
           }
         }
       };

--- a/src/routing/lb_raptor.cc
+++ b/src/routing/lb_raptor.cc
@@ -104,4 +104,16 @@ void lb_raptor(
   }
 }
 
+template void lb_raptor<direction::kForward>(
+    timetable const&,
+    query const&,
+    raptor_state&,
+    vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>&);
+
+template void lb_raptor<direction::kBackward>(
+    timetable const&,
+    query const&,
+    raptor_state&,
+    vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>&);
+
 }  // namespace nigiri::routing

--- a/src/routing/lb_raptor.cc
+++ b/src/routing/lb_raptor.cc
@@ -1,5 +1,6 @@
 #include "nigiri/routing/lb_raptor.h"
 
+#include "nigiri/for_each_meta.h"
 #include "nigiri/routing/query.h"
 #include "nigiri/routing/raptor/raptor_state.h"
 #include "nigiri/timetable.h"
@@ -27,8 +28,11 @@ void lb_raptor(
   utl::fill(location_round_lb, kRoundLbInit);
 
   for (auto const& o : q.destination_) {
-    location_round_lb[o.target_].fill(o.duration_.count());
-    state.station_mark_.set(to_idx(o.target_), true);
+    for_each_meta(tt, q.dest_match_mode_, o.target_,
+                  [&](location_idx_t const x) {
+                    location_round_lb[x].fill(o.duration_.count());
+                    state.station_mark_.set(to_idx(x), true);
+                  });
   }
 
   for (auto k = 1U; k != kMaxTransfers + 2U; ++k) {

--- a/src/routing/lb_raptor.cc
+++ b/src/routing/lb_raptor.cc
@@ -71,11 +71,11 @@ void lb_raptor(
       auto const l = location_idx_t{i};
 
       auto const expand = [&](footpath const& e) {
-        auto const new_lb = static_cast<std::uint16_t>(location_round_lb[l][k] +
-                                                       e.duration().count());
-        if (new_lb < location_round_lb[e.target()][k + 1U]) {
+        auto const new_lb = static_cast<std::uint16_t>(
+            location_round_lb[l][k - 1U] + e.duration().count());
+        if (new_lb < location_round_lb[e.target()][k]) {
           any_marked = true;
-          std::fill(begin(location_round_lb[e.target()]) + k + 1U,
+          std::fill(begin(location_round_lb[e.target()]) + k,
                     end(location_round_lb[e.target()]), new_lb);
           state.station_mark_.set(to_idx(e.target()), true);
         }

--- a/src/routing/lb_raptor.cc
+++ b/src/routing/lb_raptor.cc
@@ -1,5 +1,7 @@
 #include "nigiri/routing/lb_raptor.h"
 
+#include "utl/get_or_create.h"
+
 #include "nigiri/for_each_meta.h"
 #include "nigiri/routing/query.h"
 #include "nigiri/routing/raptor/raptor_state.h"
@@ -16,6 +18,7 @@ void lb_raptor(
     raptor_state& state,
     vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>&
         location_round_lb) {
+  // resize & clear
   state.prev_station_mark_.resize(tt.n_locations());
   state.station_mark_.resize(tt.n_locations());
   utl::fill(state.station_mark_.blocks_, 0U);
@@ -27,14 +30,36 @@ void lb_raptor(
   }();
   utl::fill(location_round_lb, kRoundLbInit);
 
+  // init (k = 0)
+  std::map<location_idx_t, std::uint16_t> min;
+  auto const update_min = [&](location_idx_t const l, std::uint16_t const t) {
+    auto const r = tt.locations_.get_root_idx(l);
+    auto& m =
+        utl::get_or_create(min, r, [&]() { return location_round_lb[r][0]; });
+    m = std::min(t, m);
+  };
   for (auto const& o : q.destination_) {
-    for_each_meta(tt, q.dest_match_mode_, o.target_,
-                  [&](location_idx_t const x) {
-                    location_round_lb[x].fill(o.duration_.count());
-                    state.station_mark_.set(to_idx(x), true);
-                  });
+    for_each_meta(
+        tt, q.dest_match_mode_, o.target_,
+        [&](location_idx_t const l) { update_min(l, o.duration_.count()); });
+  }
+  for (auto const& [l, tds] : q.td_dest_) {
+    for (auto const& td : tds) {
+      if (td.duration_ != footpath::kMaxDuration &&
+          td.duration_ < q.max_travel_time_) {
+        update_min(l, td.duration_.count());
+      }
+    }
+  }
+  for (auto const& [l, t] : min) {
+    for_each_meta(tt, q.dest_match_mode_, l, [&](location_idx_t const meta) {
+      location_round_lb[meta].fill(
+          std::min(t, location_round_lb[meta][0]));  // necessary to min again?
+      state.station_mark_.set(to_idx(meta), true);
+    });
   }
 
+  // run
   for (auto k = 1U; k != kMaxTransfers + 2U; ++k) {
     std::swap(state.prev_station_mark_, state.station_mark_);
     utl::fill(state.station_mark_.blocks_, 0U);

--- a/src/routing/lb_raptor.cc
+++ b/src/routing/lb_raptor.cc
@@ -11,13 +11,10 @@
 
 namespace nigiri::routing {
 
-// TODO needs search direction to use the correct footpaths
+template <direction SearchDir>
 void lb_raptor(
     timetable const& tt,
     query const& q,
-    vecvec<location_idx_t, footpath> const& lb_graph,
-    bitvec_map<location_idx_t> const* has_rt,
-    vecvec<location_idx_t, footpath> const* rt_lb_graph,
     raptor_state& state,
     vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>&
         location_round_lb) {
@@ -73,25 +70,21 @@ void lb_raptor(
     state.prev_station_mark_.for_each_set_bit([&](std::uint64_t const i) {
       auto const l = location_idx_t{i};
 
-      auto const expand = [&](footpath const& e) {
-        auto const new_lb = static_cast<std::uint16_t>(
-            location_round_lb[l][k - 1U] + e.duration().count());
-        if (new_lb < location_round_lb[e.target()][k]) {
+      auto const expand = [&](lb_neighbor const n) {
+        auto const new_lb =
+            static_cast<std::uint16_t>(location_round_lb[l][k - 1U] + n.lb_);
+        if (new_lb < location_round_lb[n.n_][k]) {
           any_marked = true;
-          std::fill(begin(location_round_lb[e.target()]) + k,
-                    end(location_round_lb[e.target()]), new_lb);
-          state.station_mark_.set(to_idx(e.target()), true);
+          std::fill(begin(location_round_lb[n.n_]) + k,
+                    end(location_round_lb[n.n_]), new_lb);
+          state.station_mark_.set(to_idx(n.n_), true);
         }
       };
 
-      for (auto const& e : lb_graph[l]) {
-        expand(e);
-      }
-
-      if (has_rt != nullptr && has_rt->test(l)) {
-        for (auto const& e : (*rt_lb_graph)[l]) {
-          expand(e);
-        }
+      for (auto const& n : (SearchDir == direction::kForward
+                                ? tt.fwd_lb_adjacency_
+                                : tt.bwd_lb_adjacency_)[q.prf_idx_][l]) {
+        expand(n);
       }
     });
     if (!any_marked) {

--- a/src/routing/lb_raptor.cc
+++ b/src/routing/lb_raptor.cc
@@ -70,7 +70,7 @@ void lb_raptor(timetable const& tt, query const& q, lb_raptor_state& state) {
 
       auto const visit = [&](lb_neighbor const n) {
         auto const lb = static_cast<std::uint16_t>(
-            state.location_round_lb_[l][k - 1U] + n.dist_);
+            state.location_round_lb_[l][k - 1U] + n.pt_duration_);
 
         if (state.is_start_.test(to_idx(n.l_)) &&
             lb < state.location_round_lb_[n.l_][k]) [[unlikely]] {

--- a/src/routing/lb_raptor.cc
+++ b/src/routing/lb_raptor.cc
@@ -7,7 +7,6 @@
 
 #include "nigiri/for_each_meta.h"
 #include "nigiri/routing/query.h"
-#include "nigiri/routing/raptor/raptor_state.h"
 #include "nigiri/timetable.h"
 
 namespace nigiri::routing {
@@ -16,7 +15,9 @@ template <direction SearchDir>
 void lb_raptor(
     timetable const& tt,
     query const& q,
-    raptor_state& state,
+    bitvec& station_mark,
+    bitvec& prev_station_mark,
+    bitvec& is_start,
     vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>&
         location_round_lb) {
   std::cout << std::endl << std::endl;
@@ -29,9 +30,9 @@ void lb_raptor(
                                : tt.locations_.footpaths_out_)[q.prf_idx_];
 
   // resize & clear
-  state.prev_station_mark_.resize(tt.n_locations());
-  state.station_mark_.resize(tt.n_locations());
-  utl::fill(state.station_mark_.blocks_, 0U);
+  prev_station_mark.resize(tt.n_locations());
+  station_mark.resize(tt.n_locations());
+  utl::fill(station_mark.blocks_, 0U);
   location_round_lb.resize(tt.n_locations());
   static constexpr auto kRoundLbInit = []() {
     auto ret = std::array<std::uint16_t, kMaxTransfers + 2>{};
@@ -39,6 +40,8 @@ void lb_raptor(
     return ret;
   }();
   utl::fill(location_round_lb, kRoundLbInit);
+  is_start.resize(tt.n_locations());
+  utl::fill(is_start.blocks_, 0U);
 
   // init (k = 0)
   std::map<location_idx_t, std::uint16_t> min;
@@ -66,36 +69,60 @@ void lb_raptor(
     for_each_meta(tt, q.dest_match_mode_, l, [&](location_idx_t const meta) {
       location_round_lb[meta].fill(
           std::min(t, location_round_lb[meta][0]));  // necessary to min again?
-      state.station_mark_.set(to_idx(meta), true);
+      station_mark.set(to_idx(meta), true);
     });
+  }
+  for (auto const& s : q.start_) {
+    is_start.set(to_idx(s.target()), true);
+  }
+  for (auto const& [l, _] : q.td_start_) {
+    is_start.set(to_idx(l), true);
   }
 
   // run
   auto k = 1U;
   for (; k != kMaxTransfers + 2U; ++k) {
     UTL_START_TIMING(lb_raptor_round);
-    std::swap(state.prev_station_mark_, state.station_mark_);
-    utl::fill(state.station_mark_.blocks_, 0U);
+    std::swap(prev_station_mark, station_mark);
+    utl::fill(station_mark.blocks_, 0U);
 
     auto any_marked = false;
-    state.prev_station_mark_.for_each_set_bit([&](std::uint64_t const i) {
+    prev_station_mark.for_each_set_bit([&](std::uint64_t const i) {
       auto const l = location_idx_t{i};
 
       auto const visit = [&](lb_neighbor const n) {
-        auto const pt_lb =
+        auto const lb =
             static_cast<std::uint16_t>(location_round_lb[l][k - 1U] + n.dist_);
-        if (pt_lb < location_round_lb[n.l_][k]) {
-          any_marked = true;
+
+        if (is_start.test(to_idx(n.l_)) && lb < location_round_lb[n.l_][k])
+            [[unlikely]] {
           std::fill(begin(location_round_lb[n.l_]) + k,
-                    end(location_round_lb[n.l_]), pt_lb);
-          state.station_mark_.set(to_idx(n.l_), true);
+                    end(location_round_lb[n.l_]), lb);
+          return;
+        }
+
+        auto const lb_transfer = static_cast<std::uint16_t>(
+            lb +
+            adjusted_transfer_time(q.transfer_time_settings_,
+                                   tt.locations_.transfer_time_[n.l_].count()));
+        if (lb_transfer < location_round_lb[n.l_][k]) {
+          std::fill(begin(location_round_lb[n.l_]) + k,
+                    end(location_round_lb[n.l_]), lb_transfer);
+          station_mark.set(to_idx(n.l_), true);
+          any_marked = true;
+
           for (auto const fp : footpaths[n.l_]) {
-            auto const walk_lb =
-                static_cast<std::uint16_t>(pt_lb + fp.duration().count());
-            if (walk_lb < location_round_lb[fp.target()][k]) {
+            if (is_start.test(to_idx(fp.target()))) [[unlikely]] {
+              continue;
+            }
+
+            auto const lb_fp = static_cast<std::uint16_t>(
+                lb + adjusted_transfer_time(q.transfer_time_settings_,
+                                            fp.duration().count()));
+            if (lb_fp < location_round_lb[fp.target()][k]) {
               std::fill(begin(location_round_lb[fp.target()]) + k,
-                        end(location_round_lb[fp.target()]), walk_lb);
-              state.station_mark_.set(to_idx(fp.target()), true);
+                        end(location_round_lb[fp.target()]), lb_fp);
+              station_mark.set(to_idx(fp.target()), true);
             }
           }
         }
@@ -107,8 +134,11 @@ void lb_raptor(
     });
     UTL_STOP_TIMING(lb_raptor_round);
     fmt::println("lb_raptor_round, k: {}, #marked: {}, time: {} ms", k,
-                 state.prev_station_mark_.count(),
-                 UTL_TIMING_MS(lb_raptor_round));
+                 prev_station_mark.count(), UTL_TIMING_MS(lb_raptor_round));
+
+    for (auto const& s : q.start_) {
+      fmt::println("k: {}, s: {}", k, location_round_lb[s.target()]);
+    }
 
     if (!any_marked) {
       break;
@@ -134,13 +164,17 @@ void lb_raptor(
 template void lb_raptor<direction::kForward>(
     timetable const&,
     query const&,
-    raptor_state&,
+    bitvec&,
+    bitvec&,
+    bitvec&,
     vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>&);
 
 template void lb_raptor<direction::kBackward>(
     timetable const&,
     query const&,
-    raptor_state&,
+    bitvec&,
+    bitvec&,
+    bitvec&,
     vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>&);
 
 }  // namespace nigiri::routing

--- a/src/routing/lb_raptor.cc
+++ b/src/routing/lb_raptor.cc
@@ -13,10 +13,9 @@ void lb_raptor(
     bitvec_map<location_idx_t> const* has_rt,
     vecvec<location_idx_t, footpath> const* rt_lb_graph,
     raptor_state& state,
-    vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2>>&
+    vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>&
         location_round_lb) {
   state.prev_station_mark_.resize(tt.n_locations());
-  utl::fill(state.prev_station_mark_.blocks_, 0U);
   state.station_mark_.resize(tt.n_locations());
   utl::fill(state.station_mark_.blocks_, 0U);
   location_round_lb.resize(tt.n_locations());
@@ -26,6 +25,28 @@ void lb_raptor(
     return ret;
   }();
   utl::fill(location_round_lb, kRoundLbInit);
-}
 
+  for (auto const& o : q.destination_) {
+    location_round_lb[o.target_].fill(o.duration_.count());
+    state.station_mark_.set(to_idx(o.target_), true);
+  }
+
+  for (auto k = 1U; k != kMaxTransfers + 2U; ++k) {
+    std::swap(state.prev_station_mark_, state.station_mark_);
+    utl::fill(state.station_mark_.blocks_, 0U);
+
+    auto any_marked = false;
+    state.prev_station_mark_.for_each_set_bit([&](std::uint64_t const i) {
+      any_marked = true;
+      // follow lb graph and/or rt lb graph from this station
+      // for each edge
+      // check if time of this station + edge duration leads to an improvement
+      // for the next round if yes write improved time to location_round_lb mark
+      // the station with the improved time for the next round
+    });
+    if (!any_marked) {
+      return;
+    }
+  }
+}
 }  // namespace nigiri::routing

--- a/src/routing/lb_raptor.cc
+++ b/src/routing/lb_raptor.cc
@@ -11,6 +11,7 @@
 
 namespace nigiri::routing {
 
+// TODO needs search direction to use the correct footpaths
 void lb_raptor(
     timetable const& tt,
     query const& q,
@@ -63,6 +64,8 @@ void lb_raptor(
 
   // run
   for (auto const k : interval{1U, kMaxTransfers + 2U}) {
+    // TODO expand footpaths from/to marked stations, they are reached in k-1
+
     std::swap(state.prev_station_mark_, state.station_mark_);
     utl::fill(state.station_mark_.blocks_, 0U);
 

--- a/src/routing/lb_raptor.cc
+++ b/src/routing/lb_raptor.cc
@@ -2,6 +2,7 @@
 
 #include "utl/enumerate.h"
 #include "utl/get_or_create.h"
+#include "utl/timing.h"
 #include "utl/zip.h"
 
 #include "nigiri/for_each_meta.h"
@@ -18,6 +19,15 @@ void lb_raptor(
     raptor_state& state,
     vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>&
         location_round_lb) {
+  std::cout << std::endl << std::endl;
+  UTL_START_TIMING(lb_raptor);
+  auto const& adjacency =
+      (SearchDir == direction::kForward ? tt.fwd_lb_adjacency_
+                                        : tt.bwd_lb_adjacency_)[q.prf_idx_];
+  auto const& footpaths = (SearchDir == direction::kForward
+                               ? tt.locations_.footpaths_in_
+                               : tt.locations_.footpaths_out_)[q.prf_idx_];
+
   // resize & clear
   state.prev_station_mark_.resize(tt.n_locations());
   state.station_mark_.resize(tt.n_locations());
@@ -40,14 +50,15 @@ void lb_raptor(
   };
   for (auto const& o : q.destination_) {
     for_each_meta(
-        tt, q.dest_match_mode_, o.target(),
-        [&](location_idx_t const l) { update_min(l, o.duration().count()); });
+        tt, q.dest_match_mode_, o.target(), [&](location_idx_t const l) {
+          update_min(l, static_cast<std::uint16_t>(o.duration().count()));
+        });
   }
   for (auto const& [l, tds] : q.td_dest_) {
     for (auto const& td : tds) {
       if (td.duration() != footpath::kMaxDuration &&
           td.duration() < q.max_travel_time_) {
-        update_min(l, td.duration().count());
+        update_min(l, static_cast<std::uint16_t>(td.duration().count()));
       }
     }
   }
@@ -58,67 +69,66 @@ void lb_raptor(
       state.station_mark_.set(to_idx(meta), true);
     });
   }
-  auto const& footpaths = SearchDir == direction::kForward
-                              ? tt.locations_.footpaths_in_[q.prf_idx_]
-                              : tt.locations_.footpaths_out_[q.prf_idx_];
 
   // run
-  for (auto const k : interval{1U, kMaxTransfers + 2U}) {
+  auto k = 1U;
+  for (; k != kMaxTransfers + 2U; ++k) {
+    UTL_START_TIMING(lb_raptor_round);
     std::swap(state.prev_station_mark_, state.station_mark_);
-    utl::fill(state.station_mark_.blocks_, 0U);
-
-    state.prev_station_mark_.for_each_set_bit([&](std::uint64_t const i) {
-      auto const l = location_idx_t{i};
-      for (auto const& fp : footpaths[l]) {
-        auto const new_lb = static_cast<std::uint16_t>(
-            location_round_lb[l][k - 1] + fp.duration().count());
-        if (new_lb < location_round_lb[fp.target()][k - 1]) {
-          std::fill(begin(location_round_lb[fp.target()]) + k - 1,
-                    end(location_round_lb[fp.target()]), new_lb);
-          state.station_mark_.set(to_idx(fp.target()), true);
-        }
-      }
-    });
-
-    state.prev_station_mark_ |= state.station_mark_;
     utl::fill(state.station_mark_.blocks_, 0U);
 
     auto any_marked = false;
     state.prev_station_mark_.for_each_set_bit([&](std::uint64_t const i) {
       auto const l = location_idx_t{i};
 
-      auto const expand = [&](lb_neighbor const n) {
-        auto const new_lb =
-            static_cast<std::uint16_t>(location_round_lb[l][k - 1U] + n.lb_);
-        if (new_lb < location_round_lb[n.n_][k]) {
+      auto const visit = [&](lb_neighbor const n) {
+        auto const pt_lb =
+            static_cast<std::uint16_t>(location_round_lb[l][k - 1U] + n.dist_);
+        if (pt_lb < location_round_lb[n.l_][k]) {
           any_marked = true;
-          std::fill(begin(location_round_lb[n.n_]) + k,
-                    end(location_round_lb[n.n_]), new_lb);
-          state.station_mark_.set(to_idx(n.n_), true);
+          std::fill(begin(location_round_lb[n.l_]) + k,
+                    end(location_round_lb[n.l_]), pt_lb);
+          state.station_mark_.set(to_idx(n.l_), true);
+          for (auto const fp : footpaths[n.l_]) {
+            auto const walk_lb =
+                static_cast<std::uint16_t>(pt_lb + fp.duration().count());
+            if (walk_lb < location_round_lb[fp.target()][k]) {
+              std::fill(begin(location_round_lb[fp.target()]) + k,
+                        end(location_round_lb[fp.target()]), walk_lb);
+              state.station_mark_.set(to_idx(fp.target()), true);
+            }
+          }
         }
       };
 
-      for (auto const& n : (SearchDir == direction::kForward
-                                ? tt.fwd_lb_adjacency_
-                                : tt.bwd_lb_adjacency_)[q.prf_idx_][l]) {
-        expand(n);
+      for (auto const n : adjacency[l]) {
+        visit(n);
       }
     });
+    UTL_STOP_TIMING(lb_raptor_round);
+    fmt::println("lb_raptor_round, k: {}, #marked: {}, time: {} ms", k,
+                 state.prev_station_mark_.count(),
+                 UTL_TIMING_MS(lb_raptor_round));
+
     if (!any_marked) {
       break;
     }
   }
 
   // propagate lb to children
-  for (auto const l :
-       interval{location_idx_t{0}, location_idx_t{tt.n_locations()}}) {
-    for (auto const c : tt.locations_.children_[l]) {
-      for (auto [plb, clb] :
-           utl::zip(location_round_lb[l], location_round_lb[c])) {
-        clb = std::min(plb, clb);
-      }
-    }
-  }
+  // for (auto const l :
+  //      interval{location_idx_t{0}, location_idx_t{tt.n_locations()}}) {
+  //   for (auto const c : tt.locations_.children_[l]) {
+  //     for (auto [plb, clb] :
+  //          utl::zip(location_round_lb[l], location_round_lb[c])) {
+  //       clb = std::min(plb, clb);
+  //     }
+  //   }
+  // }
+
+  UTL_STOP_TIMING(lb_raptor);
+  fmt::println("lb_raptor k: {}, time: {} ms", k, UTL_TIMING_MS(lb_raptor));
+  std::cout << std::endl << std::endl;
 }
 
 template void lb_raptor<direction::kForward>(

--- a/src/routing/lb_raptor.cc
+++ b/src/routing/lb_raptor.cc
@@ -1,5 +1,9 @@
 #include "nigiri/routing/lb_raptor.h"
 
+#include "nigiri/routing/query.h"
+#include "nigiri/routing/raptor/raptor_state.h"
+#include "nigiri/timetable.h"
+
 namespace nigiri::routing {
 
 void lb_raptor(
@@ -8,7 +12,20 @@ void lb_raptor(
     vecvec<location_idx_t, footpath> const& lb_graph,
     bitvec_map<location_idx_t> const* has_rt,
     vecvec<location_idx_t, footpath> const* rt_lb_graph,
+    raptor_state& state,
     vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2>>&
-        location_round_lb) {}
+        location_round_lb) {
+  state.prev_station_mark_.resize(tt.n_locations());
+  utl::fill(state.prev_station_mark_.blocks_, 0U);
+  state.station_mark_.resize(tt.n_locations());
+  utl::fill(state.station_mark_.blocks_, 0U);
+  location_round_lb.resize(tt.n_locations());
+  static constexpr auto kRoundLbInit = []() {
+    auto ret = std::array<std::uint16_t, kMaxTransfers + 2>{};
+    ret.fill(std::numeric_limits<std::uint16_t>::max());
+    return ret;
+  }();
+  utl::fill(location_round_lb, kRoundLbInit);
+}
 
 }  // namespace nigiri::routing

--- a/src/routing/lb_raptor.cc
+++ b/src/routing/lb_raptor.cc
@@ -12,16 +12,7 @@
 namespace nigiri::routing {
 
 template <direction SearchDir>
-void lb_raptor(
-    timetable const& tt,
-    query const& q,
-    bitvec& station_mark,
-    bitvec& prev_station_mark,
-    bitvec& is_start,
-    vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>&
-        location_round_lb) {
-  std::cout << std::endl << std::endl;
-  UTL_START_TIMING(lb_raptor);
+void lb_raptor(timetable const& tt, query const& q, lb_raptor_state& state) {
   auto const& adjacency =
       (SearchDir == direction::kForward ? tt.fwd_lb_adjacency_
                                         : tt.bwd_lb_adjacency_)[q.prf_idx_];
@@ -29,26 +20,15 @@ void lb_raptor(
                                ? tt.locations_.footpaths_in_
                                : tt.locations_.footpaths_out_)[q.prf_idx_];
 
-  // resize & clear
-  prev_station_mark.resize(tt.n_locations());
-  station_mark.resize(tt.n_locations());
-  utl::fill(station_mark.blocks_, 0U);
-  location_round_lb.resize(tt.n_locations());
-  static constexpr auto kRoundLbInit = []() {
-    auto ret = std::array<std::uint16_t, kMaxTransfers + 2>{};
-    ret.fill(std::numeric_limits<std::uint16_t>::max());
-    return ret;
-  }();
-  utl::fill(location_round_lb, kRoundLbInit);
-  is_start.resize(tt.n_locations());
-  utl::fill(is_start.blocks_, 0U);
+  state.resize(tt.n_locations());
+  state.clear();
 
   // init (k = 0)
   std::map<location_idx_t, std::uint16_t> min;
   auto const update_min = [&](location_idx_t const l, std::uint16_t const t) {
     auto const r = tt.locations_.get_root_idx(l);
-    auto& m =
-        utl::get_or_create(min, r, [&]() { return location_round_lb[r][0]; });
+    auto& m = utl::get_or_create(
+        min, r, [&] { return state.location_round_lb_[r][0]; });
     m = std::min(t, m);
   };
   for (auto const& o : q.destination_) {
@@ -67,37 +47,35 @@ void lb_raptor(
   }
   for (auto const& [l, t] : min) {
     for_each_meta(tt, q.dest_match_mode_, l, [&](location_idx_t const meta) {
-      location_round_lb[meta].fill(
-          std::min(t, location_round_lb[meta][0]));  // necessary to min again?
-      station_mark.set(to_idx(meta), true);
+      state.location_round_lb_[meta].fill(std::min(
+          t, state.location_round_lb_[meta][0]));  // necessary to min again?
+      state.station_mark_.set(to_idx(meta), true);
     });
   }
   for (auto const& s : q.start_) {
-    is_start.set(to_idx(s.target()), true);
+    state.is_start_.set(to_idx(s.target()), true);
   }
   for (auto const& [l, _] : q.td_start_) {
-    is_start.set(to_idx(l), true);
+    state.is_start_.set(to_idx(l), true);
   }
 
   // run
-  auto k = 1U;
-  for (; k != kMaxTransfers + 2U; ++k) {
-    UTL_START_TIMING(lb_raptor_round);
-    std::swap(prev_station_mark, station_mark);
-    utl::fill(station_mark.blocks_, 0U);
+  for (auto k = 1U; k != std::min(q.max_transfers_, kMaxTransfers) + 2U; ++k) {
+    std::swap(state.prev_station_mark_, state.station_mark_);
+    utl::fill(state.station_mark_.blocks_, 0U);
 
     auto any_marked = false;
-    prev_station_mark.for_each_set_bit([&](std::uint64_t const i) {
+    state.prev_station_mark_.for_each_set_bit([&](std::uint64_t const i) {
       auto const l = location_idx_t{i};
 
       auto const visit = [&](lb_neighbor const n) {
-        auto const lb =
-            static_cast<std::uint16_t>(location_round_lb[l][k - 1U] + n.dist_);
+        auto const lb = static_cast<std::uint16_t>(
+            state.location_round_lb_[l][k - 1U] + n.dist_);
 
-        if (is_start.test(to_idx(n.l_)) && lb < location_round_lb[n.l_][k])
-            [[unlikely]] {
-          std::fill(begin(location_round_lb[n.l_]) + k,
-                    end(location_round_lb[n.l_]), lb);
+        if (state.is_start_.test(to_idx(n.l_)) &&
+            lb < state.location_round_lb_[n.l_][k]) [[unlikely]] {
+          std::fill(begin(state.location_round_lb_[n.l_]) + k,
+                    end(state.location_round_lb_[n.l_]), lb);
           return;
         }
 
@@ -105,24 +83,24 @@ void lb_raptor(
             lb +
             adjusted_transfer_time(q.transfer_time_settings_,
                                    tt.locations_.transfer_time_[n.l_].count()));
-        if (lb_transfer < location_round_lb[n.l_][k]) {
-          std::fill(begin(location_round_lb[n.l_]) + k,
-                    end(location_round_lb[n.l_]), lb_transfer);
-          station_mark.set(to_idx(n.l_), true);
+        if (lb_transfer < state.location_round_lb_[n.l_][k]) {
+          std::fill(begin(state.location_round_lb_[n.l_]) + k,
+                    end(state.location_round_lb_[n.l_]), lb_transfer);
+          state.station_mark_.set(to_idx(n.l_), true);
           any_marked = true;
 
           for (auto const fp : footpaths[n.l_]) {
-            if (is_start.test(to_idx(fp.target()))) [[unlikely]] {
+            if (state.is_start_.test(to_idx(fp.target()))) [[unlikely]] {
               continue;
             }
 
             auto const lb_fp = static_cast<std::uint16_t>(
                 lb + adjusted_transfer_time(q.transfer_time_settings_,
                                             fp.duration().count()));
-            if (lb_fp < location_round_lb[fp.target()][k]) {
-              std::fill(begin(location_round_lb[fp.target()]) + k,
-                        end(location_round_lb[fp.target()]), lb_fp);
-              station_mark.set(to_idx(fp.target()), true);
+            if (lb_fp < state.location_round_lb_[fp.target()][k]) {
+              std::fill(begin(state.location_round_lb_[fp.target()]) + k,
+                        end(state.location_round_lb_[fp.target()]), lb_fp);
+              state.station_mark_.set(to_idx(fp.target()), true);
             }
           }
         }
@@ -132,13 +110,6 @@ void lb_raptor(
         visit(n);
       }
     });
-    UTL_STOP_TIMING(lb_raptor_round);
-    fmt::println("lb_raptor_round, k: {}, #marked: {}, time: {} ms", k,
-                 prev_station_mark.count(), UTL_TIMING_MS(lb_raptor_round));
-
-    for (auto const& s : q.start_) {
-      fmt::println("k: {}, s: {}", k, location_round_lb[s.target()]);
-    }
 
     if (!any_marked) {
       break;
@@ -155,26 +126,14 @@ void lb_raptor(
   //     }
   //   }
   // }
-
-  UTL_STOP_TIMING(lb_raptor);
-  fmt::println("lb_raptor k: {}, time: {} ms", k, UTL_TIMING_MS(lb_raptor));
-  std::cout << std::endl << std::endl;
 }
 
-template void lb_raptor<direction::kForward>(
-    timetable const&,
-    query const&,
-    bitvec&,
-    bitvec&,
-    bitvec&,
-    vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>&);
+template void lb_raptor<direction::kForward>(timetable const&,
+                                             query const&,
+                                             lb_raptor_state&);
 
-template void lb_raptor<direction::kBackward>(
-    timetable const&,
-    query const&,
-    bitvec&,
-    bitvec&,
-    bitvec&,
-    vector_map<location_idx_t, std::array<std::uint16_t, kMaxTransfers + 2U>>&);
+template void lb_raptor<direction::kBackward>(timetable const&,
+                                              query const&,
+                                              lb_raptor_state&);
 
 }  // namespace nigiri::routing

--- a/src/routing/one_to_all.cc
+++ b/src/routing/one_to_all.cc
@@ -65,7 +65,9 @@ raptor_state one_to_all(timetable const& tt,
   auto is_dest = bitvec{tt.n_locations()};  // Keep footpath time for each stop
   auto is_via = std::array<bitvec, kMaxVias>{};
   auto dist_to_dest = std::vector<std::uint16_t>{};
-  auto lb = std::vector<std::uint16_t>(tt.n_locations(), 0U);
+  auto lb = lb_raptor_state{};
+  lb.resize(tt.n_locations());
+  lb.zeroize();
   auto const base = make_base(tt, start_time);
   auto const is_wheelchair = q.prf_idx_ == kWheelchairProfile;
 
@@ -77,7 +79,7 @@ raptor_state one_to_all(timetable const& tt,
       is_via,
       dist_to_dest,
       q.td_dest_,
-      lb,
+      lb.location_round_lb_,
       q.via_stops_,
       base,
       q.allowed_claszes_,

--- a/src/routing/raptor/pong.cc
+++ b/src/routing/raptor/pong.cc
@@ -282,17 +282,12 @@ routing_result pong(timetable const& tt,
   // PING
   // ----
   UTL_START_TIMING(ping_lb);
-  auto ping_lb = std::vector<std::uint16_t>{};
-  dijkstra(tt, q,
-           (kFwd ? tt.fwd_search_lb_graph_[q.prf_idx_]
-                 : tt.bwd_search_lb_graph_[q.prf_idx_]),
-           (rtt == nullptr ? nullptr
-                           : &(kFwd ? rtt->fwd_search_lb_graph_has_edges_
-                                    : rtt->bwd_search_lb_graph_has_edges_)),
-           (rtt == nullptr ? nullptr
-                           : &(kFwd ? rtt->fwd_search_lb_graph_
-                                    : rtt->bwd_search_lb_graph_)),
-           ping_lb);
+  auto ping_lb = lb_raptor_state{};
+  if (q.prf_idx_ == kDefaultProfile) {
+    lb_raptor<SearchDir>(tt, q, ping_lb);
+  } else {
+    ping_lb.zeroize();
+  }
   UTL_STOP_TIMING(ping_lb);
 
   auto ping_dist_to_dest = std::vector<std::uint16_t>{};
@@ -312,7 +307,7 @@ routing_result pong(timetable const& tt,
       ping_is_via,
       ping_dist_to_dest,
       q.td_dest_,
-      ping_lb,
+      ping_lb.location_round_lb_,
       q.via_stops_,
       base_day,
       q.allowed_claszes_,
@@ -327,17 +322,12 @@ routing_result pong(timetable const& tt,
   q.flip_dir();
 
   UTL_START_TIMING(pong_lb);
-  auto pong_lb = std::vector<std::uint16_t>{};
-  dijkstra(tt, q,
-           (kFwd ? tt.bwd_search_lb_graph_[q.prf_idx_]
-                 : tt.fwd_search_lb_graph_[q.prf_idx_]),
-           (rtt == nullptr ? nullptr
-                           : &(kFwd ? rtt->bwd_search_lb_graph_has_edges_
-                                    : rtt->fwd_search_lb_graph_has_edges_)),
-           (rtt == nullptr ? nullptr
-                           : &(kFwd ? rtt->bwd_search_lb_graph_
-                                    : rtt->fwd_search_lb_graph_)),
-           pong_lb);
+  auto pong_lb = lb_raptor_state{};
+  if (q.prf_idx_ == kDefaultProfile) {
+    lb_raptor<SearchDir>(tt, q, pong_lb);
+  } else {
+    pong_lb.zeroize();
+  }
   UTL_STOP_TIMING(pong_lb);
 
   auto pong_dist_to_dest = std::vector<std::uint16_t>{};
@@ -358,7 +348,7 @@ routing_result pong(timetable const& tt,
       pong_is_via,
       pong_dist_to_dest,
       q.td_dest_,
-      pong_lb,
+      pong_lb.location_round_lb_,
       q.via_stops_,
       base_day,
       q.allowed_claszes_,

--- a/src/routing/tb/query_engine.cc
+++ b/src/routing/tb/query_engine.cc
@@ -12,6 +12,9 @@
 #include "nigiri/routing/journey.h"
 #include "nigiri/routing/raptor/reconstruct.h"
 #include "nigiri/routing/tb/query_engine.h"
+
+#include "nigiri/loader/register.h"
+
 #include "nigiri/routing/tb/segment_info.h"
 #include "nigiri/routing/tb/settings.h"
 #include "nigiri/rt/frun.h"
@@ -31,7 +34,9 @@ query_engine<UseLowerBounds>::query_engine(
     std::array<bitvec, kMaxVias> const&,
     std::vector<std::uint16_t> const& dist_to_dest,
     hash_map<location_idx_t, std::vector<td_offset>> const&,
-    std::vector<std::uint16_t> const& lb,
+    vector_map<location_idx_t,
+               std::array<std::uint16_t, kMaxTransfers + 2U>> const&
+        location_round_lb,
     std::vector<via_stop> const&,
     day_idx_t const base,
     clasz_mask_t,
@@ -43,7 +48,7 @@ query_engine<UseLowerBounds>::query_engine(
       state_{state},
       is_dest_{is_dest},
       dist_to_dest_{dist_to_dest},
-      lb_{lb},
+      location_round_lb_{location_round_lb},
       base_{base - QUERY_DAY_SHIFT} {
   state_.q_n_.base_ = base_;
   stats_.lower_bound_pruning_ = UseLowerBounds;
@@ -113,11 +118,12 @@ void query_engine<UseLowerBounds>::execute(unixtime_t const start_time,
       interval{queue_idx_t{0U}, static_cast<queue_idx_t>(state_.q_n_.size())};
   for (; k != kMaxTransfers && !round.empty(); ++k) {
     tb_debug("ROUND start_time={}, k={}", start_time, k);
+    auto const remaining_k = static_cast<std::uint32_t>(kMaxTransfers - k);
     for (auto const i : round) {
       seg_dest(k, i);
     }
     for (auto const i : round) {
-      seg_prune(k, state_.q_n_[i]);
+      seg_prune(k, remaining_k, state_.q_n_[i]);
     }
     for (auto const i : round) {
       seg_transfers(i, k);
@@ -175,6 +181,7 @@ void query_engine<UseLowerBounds>::seg_dest(std::uint8_t const k,
 
 template <bool UseLowerBounds>
 void query_engine<UseLowerBounds>::seg_prune(std::uint8_t const k,
+                                             unsigned const remaining_k,
                                              queue_entry& qe) {
   auto const segment = qe.segment_range_[0];
   auto const t = state_.tbd_.segment_transports_[segment];
@@ -185,7 +192,7 @@ void query_engine<UseLowerBounds>::seg_prune(std::uint8_t const k,
   if constexpr (UseLowerBounds) {
     auto const l = stop{tt_.route_location_seq_[tt_.transport_route_[t]][i]}
                        .location_idx();
-    arr_time += duration_t{lb_[to_idx(l)]};
+    arr_time += duration_t{location_round_lb_[l][remaining_k]};
   }
   if (arr_time > state_.t_min_[k + 1]) {
     tb_debug("PRUNING {}", seg(segment, qe));

--- a/test/loader/lb_adjacency_test.cc
+++ b/test/loader/lb_adjacency_test.cc
@@ -1,0 +1,80 @@
+#include "gtest/gtest.h"
+
+#include "utl/enumerate.h"
+
+#include "nigiri/timetable.h"
+
+#include "../util.h"
+
+using namespace date;
+using namespace nigiri;
+using namespace nigiri::loader;
+using namespace nigiri::routing;
+
+mem_dir adjacency_test_tt() {
+  return mem_dir::read(R"__(
+"(
+# agency.txt
+agency_id,agency_name,agency_url,agency_timezone
+MTA,MOTIS Transit Authority,https://motis-project.de/,Europe/Berlin
+
+# calendar_dates.txt
+service_id,date,exception_type
+SID,20260227,1
+
+# stops.txt
+stop_id,stop_name,stop_desc,stop_lat,stop_lon,stop_url,location_type,parent_station
+A1,A1,,,,,,
+A2,A2,,,,,,
+A3,A3,,,,,,
+
+# routes.txt
+route_id,agency_id,route_short_name,route_long_name,route_desc,route_type
+A,MTA,A,A,A1 -> A2 -> A3,0
+F,MTA,F,F,A2 -> A3,0
+
+# trips.txt
+route_id,service_id,trip_id,trip_headsign,block_id
+A,SID,A,A,0
+F,SID,F,F,0
+
+# stop_times.txt
+trip_id,arrival_time,departure_time,stop_id,stop_sequence,pickup_type,drop_off_type
+A,08:00,08:00,A1,0,0,0
+A,08:30,08:30,A2,1,0,0
+A,08:45,08:45,A3,1,0,0
+F,09:00,09:00,A2,0,0,0
+F,09:05,09:05,A3,1,0,0
+)__");
+}
+
+constexpr auto kGtfsDateRange = interval{sys_days{2026_y / February / 27},
+                                         sys_days{2026_y / February / 28}};
+
+TEST(loader, lb_adjacency) {
+  auto const tt = load_gtfs(adjacency_test_tt, kGtfsDateRange);
+
+  auto const A1 = tt.find(location_id{"A1", source_idx_t{}}).value();
+  auto const A2 = tt.find(location_id{"A2", source_idx_t{}}).value();
+  auto const A3 = tt.find(location_id{"A3", source_idx_t{}}).value();
+
+  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A1].size(), 0U);
+  ASSERT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A2].size(), 1U);
+  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A2][0].n_, A1);
+  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A2][0].lb_, 30U);
+  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3].size(), 2U);
+  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][0].n_, A1);
+  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][0].lb_, 45U);
+  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][1].n_, A2);
+  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][1].lb_, 5U);
+
+  ASSERT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1].size(), 2U);
+  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][0].n_, A2);
+  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][0].lb_, 30U);
+  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][1].n_, A3);
+  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][1].lb_, 45U);
+  ASSERT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A2].size(), 1U);
+  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A2][0].n_, A3);
+  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A2][0].lb_, 5U);
+  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A3].size(), 0U);
+}

--- a/test/loader/lb_adjacency_test.cc
+++ b/test/loader/lb_adjacency_test.cc
@@ -61,20 +61,20 @@ TEST(loader, lb_adjacency) {
   EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A1].size(), 0U);
   ASSERT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A2].size(), 1U);
   EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A2][0].l_, A1);
-  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A2][0].dist_, 30U);
+  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A2][0].pt_duration_, 30U);
   EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3].size(), 2U);
   EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][0].l_, A1);
-  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][0].dist_, 45U);
+  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][0].pt_duration_, 45U);
   EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][1].l_, A2);
-  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][1].dist_, 5U);
+  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][1].pt_duration_, 5U);
 
   ASSERT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1].size(), 2U);
   EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][0].l_, A2);
-  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][0].dist_, 30U);
+  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][0].pt_duration_, 30U);
   EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][1].l_, A3);
-  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][1].dist_, 45U);
+  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][1].pt_duration_, 45U);
   ASSERT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A2].size(), 1U);
   EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A2][0].l_, A3);
-  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A2][0].dist_, 5U);
+  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A2][0].pt_duration_, 5U);
   EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A3].size(), 0U);
 }

--- a/test/loader/lb_adjacency_test.cc
+++ b/test/loader/lb_adjacency_test.cc
@@ -60,21 +60,21 @@ TEST(loader, lb_adjacency) {
 
   EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A1].size(), 0U);
   ASSERT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A2].size(), 1U);
-  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A2][0].n_, A1);
-  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A2][0].lb_, 30U);
+  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A2][0].l_, A1);
+  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A2][0].dist_, 30U);
   EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3].size(), 2U);
-  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][0].n_, A1);
-  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][0].lb_, 45U);
-  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][1].n_, A2);
-  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][1].lb_, 5U);
+  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][0].l_, A1);
+  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][0].dist_, 45U);
+  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][1].l_, A2);
+  EXPECT_EQ(tt.fwd_lb_adjacency_[kDefaultProfile][A3][1].dist_, 5U);
 
   ASSERT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1].size(), 2U);
-  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][0].n_, A2);
-  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][0].lb_, 30U);
-  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][1].n_, A3);
-  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][1].lb_, 45U);
+  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][0].l_, A2);
+  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][0].dist_, 30U);
+  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][1].l_, A3);
+  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A1][1].dist_, 45U);
   ASSERT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A2].size(), 1U);
-  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A2][0].n_, A3);
-  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A2][0].lb_, 5U);
+  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A2][0].l_, A3);
+  EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A2][0].dist_, 5U);
   EXPECT_EQ(tt.bwd_lb_adjacency_[kDefaultProfile][A3].size(), 0U);
 }

--- a/test/routing/lb_raptor_test.cc
+++ b/test/routing/lb_raptor_test.cc
@@ -137,24 +137,28 @@ TEST(routing, lb_raptor) {
   auto const tt = load_gtfs(lb_test_tt, kGtfsDateRange);
   auto rtt = rt::create_rt_timetable(tt, sys_days{2026_y / February / 27});
   auto const T = tt.find(location_id{"T", source_idx_t{}}).value();
-  auto const q =
-      query{.start_time_ = unixtime_t{sys_days{February / 27 / 2026}},
-            .destination_ = {{tt.locations_.location_id_to_idx_.at(
-                                  {"T", source_idx_t{0U}}),
-                              13_minutes, 0U}},
-            .td_dest_{{T,
-                       {{.valid_from_ = sys_days{2026_y / January / 27},
-                         .duration_ = 7_minutes,
-                         .transport_mode_id_ = 5},
-                        {.valid_from_ = sys_days{2026_y / January / 28},
-                         .duration_ = footpath::kMaxDuration,
-                         .transport_mode_id_ = 5}}}}};
-  auto state = raptor_state{};
+  auto const q = query{
+      .start_time_ = unixtime_t{sys_days{February / 27 / 2026}},
+      .start_ = {{tt.locations_.location_id_to_idx_.at({"P", source_idx_t{0U}}),
+                  3_minutes, 0U}},
+      .destination_ = {{tt.locations_.location_id_to_idx_.at(
+                            {"T", source_idx_t{0U}}),
+                        13_minutes, 0U}},
+      .td_dest_{{T,
+                 {{.valid_from_ = sys_days{2026_y / January / 27},
+                   .duration_ = 7_minutes,
+                   .transport_mode_id_ = 5},
+                  {.valid_from_ = sys_days{2026_y / January / 28},
+                   .duration_ = footpath::kMaxDuration,
+                   .transport_mode_id_ = 5}}}}};
   auto location_round_lb =
       vector_map<location_idx_t,
                  std::array<std::uint16_t, kMaxTransfers + 2U>>{};
-
-  lb_raptor<direction::kForward>(tt, q, state, location_round_lb);
+  auto station_mark = bitvec{};
+  auto prev_station_mark = bitvec{};
+  auto is_start = bitvec{};
+  lb_raptor<direction::kForward>(tt, q, station_mark, prev_station_mark,
+                                 is_start, location_round_lb);
 
   for (auto const [i, round_lb] : utl::enumerate(location_round_lb)) {
     fmt::println("{}: {}", tt.get_default_name(location_idx_t{i}), round_lb);

--- a/test/routing/lb_raptor_test.cc
+++ b/test/routing/lb_raptor_test.cc
@@ -103,6 +103,31 @@ F,S,2,600
 constexpr auto kGtfsDateRange = interval{sys_days{2026_y / February / 27},
                                          sys_days{2026_y / February / 28}};
 
+constexpr auto kExpLbP = std::array<std::uint16_t, 16U>{
+    65535U, 65535U, 578U, 487U, 247U, 142U, 142U, 142U,
+    142U,   142U,   142U, 142U, 142U, 142U, 142U, 142U};
+constexpr auto kExpLbF = std::array<std::uint16_t, 16U>{/* TODO F should be reached in k = 1 already, since it only takes one transport and a footpath. It follows that lb_raptor needs the search direction to cor*/};
+constexpr auto kExpLbS = std::array<std::uint16_t, 16U>{
+    65535U, 518U, 427U, 187U, 82U, 82U, 82U, 82U,
+    82U,    82U,  82U,  82U,  82U, 82U, 82U, 82U};
+constexpr auto kExpLbB1 = std::array<std::uint16_t, 16U>{
+    65535U, 187U, 187U, 187U, 187U, 187U, 187U, 187U,
+    187U,   187U, 187U, 187U, 187U, 187U, 187U, 187U};
+constexpr auto kExpLbC1 = std::array<std::uint16_t, 16U>{
+    65535U, 65535U, 127U, 127U, 127U, 127U, 127U, 127U,
+    127U,   127U,   127U, 127U, 127U, 127U, 127U, 127U};
+constexpr auto kExpLbC2 =
+    std::array<std::uint16_t, 16U>{65535U, 67U, 67U, 67U, 67U, 67U, 67U, 67U,
+                                   67U,    67U, 67U, 67U, 67U, 67U, 67U, 67U};
+constexpr auto kExpLbD1 = std::array<std::uint16_t, 16U>{
+    65535U, 65535U, 65535U, 67U, 67U, 67U, 67U, 67U,
+    67U,    67U,    67U,    67U, 67U, 67U, 67U, 67U};
+constexpr auto kExpLbD2 = std::array<std::uint16_t, 16U>{
+    65535U, 65535U, 52U, 52U, 52U, 52U, 52U, 52U,
+    52U,    52U,    52U, 52U, 52U, 52U, 52U, 52U};
+constexpr auto kExpLbD3 =
+    std::array<std::uint16_t, 16U>{65535U, 37U, 37U, 37U, 37U, 37U, 37U, 37U,
+                                   37U,    37U, 37U, 37U, 37U, 37U, 37U, 37U};
 constexpr auto kExpLbT = std::array<std::uint16_t, 16U>{
     7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U};
 

--- a/test/routing/lb_raptor_test.cc
+++ b/test/routing/lb_raptor_test.cc
@@ -1,9 +1,5 @@
 #include "gtest/gtest.h"
 
-#include <ranges>
-
-#include "utl/enumerate.h"
-
 #include "nigiri/routing/lb_raptor.h"
 #include "nigiri/routing/raptor/raptor_state.h"
 #include "nigiri/rt/create_rt_timetable.h"
@@ -104,39 +100,38 @@ constexpr auto kGtfsDateRange = interval{sys_days{2026_y / February / 27},
                                          sys_days{2026_y / February / 28}};
 
 constexpr auto kExpLbP = std::array<std::uint16_t, 16U>{
-    65535U, 65535U, 667U, 487U, 247U, 142U, 142U, 142U,
-    142U,   142U,   142U, 142U, 142U, 142U, 142U, 142U};
+    65535U, 65535U, 669U, 491U, 253U, 150U, 150U, 150U,
+    150U,   150U,   150U, 150U, 150U, 150U, 150U, 150U};
 constexpr auto kExpLbF = std::array<std::uint16_t, 16U>{
-    65535U, 617U, 437U, 197U, 92U, 92U, 92U, 92U,
-    92U,    92U,  92U,  92U,  92U, 92U, 92U, 92U};
+    65535U, 617U, 439U, 201U, 98U, 98U, 98U, 98U,
+    98U,    98U,  98U,  98U,  98U, 98U, 98U, 98U};
 constexpr auto kExpLbS = std::array<std::uint16_t, 16U>{
-    65535U, 607U, 427U, 187U, 82U, 82U, 82U, 82U,
-    82U,    82U,  82U,  82U,  82U, 82U, 82U, 82U};
+    65535U, 609U, 431U, 193U, 90U, 90U, 90U, 90U,
+    90U,    90U,  90U,  90U,  90U, 90U, 90U, 90U};
 constexpr auto kExpLbB1 = std::array<std::uint16_t, 16U>{
-    65535U, 187U, 187U, 187U, 187U, 187U, 187U, 187U,
-    187U,   187U, 187U, 187U, 187U, 187U, 187U, 187U};
+    65535U, 189U, 189U, 189U, 189U, 189U, 189U, 189U,
+    189U,   189U, 189U, 189U, 189U, 189U, 189U, 189U};
 constexpr auto kExpLbC1 = std::array<std::uint16_t, 16U>{
-    65535U, 65535U, 127U, 127U, 127U, 127U, 127U, 127U,
-    127U,   127U,   127U, 127U, 127U, 127U, 127U, 127U};
+    65535U, 65535U, 131U, 131U, 131U, 131U, 131U, 131U,
+    131U,   131U,   131U, 131U, 131U, 131U, 131U, 131U};
 constexpr auto kExpLbC2 =
-    std::array<std::uint16_t, 16U>{65535U, 67U, 67U, 67U, 67U, 67U, 67U, 67U,
-                                   67U,    67U, 67U, 67U, 67U, 67U, 67U, 67U};
+    std::array<std::uint16_t, 16U>{65535U, 69U, 69U, 69U, 69U, 69U, 69U, 69U,
+                                   69U,    69U, 69U, 69U, 69U, 69U, 69U, 69U};
 constexpr auto kExpLbD1 = std::array<std::uint16_t, 16U>{
-    65535U, 65535U, 65535U, 67U, 67U, 67U, 67U, 67U,
-    67U,    67U,    67U,    67U, 67U, 67U, 67U, 67U};
+    65535U, 65535U, 65535U, 73U, 73U, 73U, 73U, 73U,
+    73U,    73U,    73U,    73U, 73U, 73U, 73U, 73U};
 constexpr auto kExpLbD2 = std::array<std::uint16_t, 16U>{
-    65535U, 65535U, 52U, 52U, 52U, 52U, 52U, 52U,
-    52U,    52U,    52U, 52U, 52U, 52U, 52U, 52U};
+    65535U, 65535U, 56U, 56U, 56U, 56U, 56U, 56U,
+    56U,    56U,    56U, 56U, 56U, 56U, 56U, 56U};
 constexpr auto kExpLbD3 =
-    std::array<std::uint16_t, 16U>{65535U, 37U, 37U, 37U, 37U, 37U, 37U, 37U,
-                                   37U,    37U, 37U, 37U, 37U, 37U, 37U, 37U};
+    std::array<std::uint16_t, 16U>{65535U, 39U, 39U, 39U, 39U, 39U, 39U, 39U,
+                                   39U,    39U, 39U, 39U, 39U, 39U, 39U, 39U};
 constexpr auto kExpLbT = std::array<std::uint16_t, 16U>{
     7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U};
 
 TEST(routing, lb_raptor) {
   auto const tt = load_gtfs(lb_test_tt, kGtfsDateRange);
   auto rtt = rt::create_rt_timetable(tt, sys_days{2026_y / February / 27});
-  auto const T = tt.find(location_id{"T", source_idx_t{}}).value();
   auto const q = query{
       .start_time_ = unixtime_t{sys_days{February / 27 / 2026}},
       .start_ = {{tt.locations_.location_id_to_idx_.at({"P", source_idx_t{0U}}),
@@ -144,7 +139,7 @@ TEST(routing, lb_raptor) {
       .destination_ = {{tt.locations_.location_id_to_idx_.at(
                             {"T", source_idx_t{0U}}),
                         13_minutes, 0U}},
-      .td_dest_{{T,
+      .td_dest_{{tt.find(location_id{"T", source_idx_t{}}).value(),
                  {{.valid_from_ = sys_days{2026_y / January / 27},
                    .duration_ = 7_minutes,
                    .transport_mode_id_ = 5},
@@ -157,40 +152,39 @@ TEST(routing, lb_raptor) {
   auto station_mark = bitvec{};
   auto prev_station_mark = bitvec{};
   auto is_start = bitvec{};
+
   lb_raptor<direction::kForward>(tt, q, station_mark, prev_station_mark,
                                  is_start, location_round_lb);
 
-  for (auto const [i, round_lb] : utl::enumerate(location_round_lb)) {
-    fmt::println("{}: {}", tt.get_default_name(location_idx_t{i}), round_lb);
-  }
-
-  ASSERT_LE(kMaxTransfers, std::uint8_t{14U});
-
-  auto const check = [](auto&& exp, auto&& act) {
-    for (auto const [e, a] :
-         std::views::zip(exp | std::views::take(kMaxTransfers + 2U),
-                         act | std::views::take(kMaxTransfers + 2U))) {
-      EXPECT_EQ(e, a);
-    }
-  };
-
-  check(kExpLbP,
-        location_round_lb[tt.find(location_id{"P", source_idx_t{}}).value()]);
-  check(kExpLbF,
-        location_round_lb[tt.find(location_id{"F", source_idx_t{}}).value()]);
-  check(kExpLbS,
-        location_round_lb[tt.find(location_id{"S", source_idx_t{}}).value()]);
-  check(kExpLbB1,
-        location_round_lb[tt.find(location_id{"B1", source_idx_t{}}).value()]);
-  check(kExpLbC1,
-        location_round_lb[tt.find(location_id{"C1", source_idx_t{}}).value()]);
-  check(kExpLbC2,
-        location_round_lb[tt.find(location_id{"C2", source_idx_t{}}).value()]);
-  check(kExpLbD1,
-        location_round_lb[tt.find(location_id{"D1", source_idx_t{}}).value()]);
-  check(kExpLbD2,
-        location_round_lb[tt.find(location_id{"D2", source_idx_t{}}).value()]);
-  check(kExpLbD3,
-        location_round_lb[tt.find(location_id{"D3", source_idx_t{}}).value()]);
-  check(kExpLbT, location_round_lb[T]);
+  ASSERT_EQ(kMaxTransfers, 14U);
+  EXPECT_EQ(
+      kExpLbP,
+      location_round_lb[tt.find(location_id{"P", source_idx_t{}}).value()]);
+  EXPECT_EQ(
+      kExpLbF,
+      location_round_lb[tt.find(location_id{"F", source_idx_t{}}).value()]);
+  EXPECT_EQ(
+      kExpLbS,
+      location_round_lb[tt.find(location_id{"S", source_idx_t{}}).value()]);
+  EXPECT_EQ(
+      kExpLbB1,
+      location_round_lb[tt.find(location_id{"B1", source_idx_t{}}).value()]);
+  EXPECT_EQ(
+      kExpLbC1,
+      location_round_lb[tt.find(location_id{"C1", source_idx_t{}}).value()]);
+  EXPECT_EQ(
+      kExpLbC2,
+      location_round_lb[tt.find(location_id{"C2", source_idx_t{}}).value()]);
+  EXPECT_EQ(
+      kExpLbD1,
+      location_round_lb[tt.find(location_id{"D1", source_idx_t{}}).value()]);
+  EXPECT_EQ(
+      kExpLbD2,
+      location_round_lb[tt.find(location_id{"D2", source_idx_t{}}).value()]);
+  EXPECT_EQ(
+      kExpLbD3,
+      location_round_lb[tt.find(location_id{"D3", source_idx_t{}}).value()]);
+  EXPECT_EQ(
+      kExpLbT,
+      location_round_lb[tt.find(location_id{"T", source_idx_t{}}).value()]);
 }

--- a/test/routing/lb_raptor_test.cc
+++ b/test/routing/lb_raptor_test.cc
@@ -104,11 +104,13 @@ constexpr auto kGtfsDateRange = interval{sys_days{2026_y / February / 27},
                                          sys_days{2026_y / February / 28}};
 
 constexpr auto kExpLbP = std::array<std::uint16_t, 16U>{
-    65535U, 65535U, 578U, 487U, 247U, 142U, 142U, 142U,
+    65535U, 65535U, 667U, 487U, 247U, 142U, 142U, 142U,
     142U,   142U,   142U, 142U, 142U, 142U, 142U, 142U};
-constexpr auto kExpLbF = std::array<std::uint16_t, 16U>{/* TODO F should be reached in k = 1 already, since it only takes one transport and a footpath. It follows that lb_raptor needs the search direction to cor*/};
+constexpr auto kExpLbF = std::array<std::uint16_t, 16U>{
+    65535U, 617U, 437U, 197U, 92U, 92U, 92U, 92U,
+    92U,    92U,  92U,  92U,  92U, 92U, 92U, 92U};
 constexpr auto kExpLbS = std::array<std::uint16_t, 16U>{
-    65535U, 518U, 427U, 187U, 82U, 82U, 82U, 82U,
+    65535U, 607U, 427U, 187U, 82U, 82U, 82U, 82U,
     82U,    82U,  82U,  82U,  82U, 82U, 82U, 82U};
 constexpr auto kExpLbB1 = std::array<std::uint16_t, 16U>{
     65535U, 187U, 187U, 187U, 187U, 187U, 187U, 187U,
@@ -168,5 +170,23 @@ TEST(routing, lb_raptor) {
     }
   };
 
+  check(kExpLbP,
+        location_round_lb[tt.find(location_id{"P", source_idx_t{}}).value()]);
+  check(kExpLbF,
+        location_round_lb[tt.find(location_id{"F", source_idx_t{}}).value()]);
+  check(kExpLbS,
+        location_round_lb[tt.find(location_id{"S", source_idx_t{}}).value()]);
+  check(kExpLbB1,
+        location_round_lb[tt.find(location_id{"B1", source_idx_t{}}).value()]);
+  check(kExpLbC1,
+        location_round_lb[tt.find(location_id{"C1", source_idx_t{}}).value()]);
+  check(kExpLbC2,
+        location_round_lb[tt.find(location_id{"C2", source_idx_t{}}).value()]);
+  check(kExpLbD1,
+        location_round_lb[tt.find(location_id{"D1", source_idx_t{}}).value()]);
+  check(kExpLbD2,
+        location_round_lb[tt.find(location_id{"D2", source_idx_t{}}).value()]);
+  check(kExpLbD3,
+        location_round_lb[tt.find(location_id{"D3", source_idx_t{}}).value()]);
   check(kExpLbT, location_round_lb[T]);
 }

--- a/test/routing/lb_raptor_test.cc
+++ b/test/routing/lb_raptor_test.cc
@@ -1,0 +1,94 @@
+#include "gtest/gtest.h"
+
+#include "nigiri/loader/gtfs/files.h"
+#include "nigiri/loader/gtfs/load_timetable.h"
+#include "nigiri/loader/init_finish.h"
+#include "nigiri/timetable.h"
+
+using namespace date;
+using namespace nigiri;
+using namespace nigiri::loader;
+using namespace nigiri::routing;
+
+mem_dir shortest_fp_files() {
+  return mem_dir::read(R"__(
+"(
+# agency.txt
+agency_id,agency_name,agency_url,agency_timezone
+MTA,MOTIS Transit Authority,https://motis-project.de/,Europe/Berlin
+
+# calendar_dates.txt
+service_id,date,exception_type
+SID,20260101,1
+
+# stops.txt
+stop_id,stop_name,stop_desc,stop_lat,stop_lon,stop_url,location_type,parent_station
+P,P,,,,,,
+F,F,,,,,,
+S,S,,,,,,
+B1,B1,,,,,,
+C1,C1,,,,,,
+C2,C2,,,,,,
+D1,D1,,,,,,
+D2,D2,,,,,,
+D3,D3,,,,,,
+T,T,,,,,,
+
+# routes.txt
+route_id,agency_id,route_short_name,route_long_name,route_desc,route_type
+PS,MTA,PS,PS,P -> S,0
+A,MTA,A,A,S -> T,0
+B1,MTA,B1,B1,S -> B1,0
+B2,MTA,B2,B2,B1 -> T,0
+C1,MTA,C1,C1,S -> C1,0
+C2,MTA,C2,C2,C1 -> C2,0
+C3,MTA,C3,C3,C2 -> T,0
+D1,MTA,D1,D1,S -> D1,0
+D2,MTA,D2,D2,D1 -> D2,0
+D3,MTA,D3,D3,D2 -> D3,0
+D4,MTA,D4,D4,D3 -> T,0
+
+# trips.txt
+route_id,service_id,trip_id,trip_headsign,block_id
+PS,SID,PS,PS,1
+A,SID,A,A,2
+B1,SID,B1,B1,3
+B2,SID,B2,B2,4
+C1,SID,C1,C1,5
+C2,SID,C2,C2,6
+C3,SID,C3,C3,7
+D1,SID,D1,D1,8
+D2,SID,D2,D2,9
+D3,SID,D3,D3,10
+D4,SID,D4,D4,11
+
+# stop_times.txt
+trip_id,arrival_time,departure_time,stop_id,stop_sequence,pickup_type,drop_off_type
+PS,03:00,03:00,P,0,0,0
+PS,04:00,04:00,S,1,0,0
+A,08:00,08:00,S,0,0,0
+A,18:00,18:00,T,1,0,0
+B1,09:00,09:00,S,0,0,0
+B1,13:00,13:00,B1,1,0,0
+B2,14:00,14:00,B2,0,0,0
+B2,17:00,17:00,T,1,0,0
+C1,10:00,10:00,S,0,0,0
+C1,11:00,11:00,C1,1,0,0
+C2,12:00,12:00,C1,0,0,0
+C2,13:00,13:00,C2,1,0,0
+C3,14:00,14:00,C2,0,0,0
+C3,15:00,15:00,T,1,0,0
+D1,11:00,11:00,S,0,0,0
+D1,11:15,11:15,D1,1,0,0
+D2,11:30,11:30,D1,0,0,0
+D2,11:45,11:45,D2,1,0,0
+D3,12:00,12:00,D2,0,0,0
+D3,12:15,12:15,D3,1,0,0
+D4,12:30,12:30,D3,0,0,0
+D4,13:00,13:00,T,0,0,0
+
+# transfers.txt
+from_stop_id,to_stop_id,transfer_type,min_transfer_time
+F,S,2,600
+)__");
+}

--- a/test/routing/lb_raptor_test.cc
+++ b/test/routing/lb_raptor_test.cc
@@ -152,8 +152,7 @@ TEST(routing, lb_raptor) {
       vector_map<location_idx_t,
                  std::array<std::uint16_t, kMaxTransfers + 2U>>{};
 
-  lb_raptor(tt, q, tt.fwd_search_lb_graph_[q.prf_idx_], nullptr, nullptr, state,
-            location_round_lb);
+  lb_raptor<direction::kForward>(tt, q, state, location_round_lb);
 
   for (auto const [i, round_lb] : utl::enumerate(location_round_lb)) {
     fmt::println("{}: {}", tt.get_default_name(location_idx_t{i}), round_lb);

--- a/test/routing/lb_raptor_test.cc
+++ b/test/routing/lb_raptor_test.cc
@@ -1,16 +1,23 @@
 #include "gtest/gtest.h"
 
-#include "nigiri/loader/gtfs/files.h"
-#include "nigiri/loader/gtfs/load_timetable.h"
-#include "nigiri/loader/init_finish.h"
+#include <ranges>
+
+#include "utl/enumerate.h"
+
+#include "nigiri/routing/lb_raptor.h"
+#include "nigiri/routing/raptor/raptor_state.h"
+#include "nigiri/rt/create_rt_timetable.h"
+#include "nigiri/rt/rt_timetable.h"
 #include "nigiri/timetable.h"
+
+#include "../util.h"
 
 using namespace date;
 using namespace nigiri;
 using namespace nigiri::loader;
 using namespace nigiri::routing;
 
-mem_dir shortest_fp_files() {
+mem_dir lb_test_tt() {
   return mem_dir::read(R"__(
 "(
 # agency.txt
@@ -19,7 +26,7 @@ MTA,MOTIS Transit Authority,https://motis-project.de/,Europe/Berlin
 
 # calendar_dates.txt
 service_id,date,exception_type
-SID,20260101,1
+SID,20260227,1
 
 # stops.txt
 stop_id,stop_name,stop_desc,stop_lat,stop_lon,stop_url,location_type,parent_station
@@ -70,7 +77,7 @@ A,08:00,08:00,S,0,0,0
 A,18:00,18:00,T,1,0,0
 B1,09:00,09:00,S,0,0,0
 B1,13:00,13:00,B1,1,0,0
-B2,14:00,14:00,B2,0,0,0
+B2,14:00,14:00,B1,0,0,0
 B2,17:00,17:00,T,1,0,0
 C1,10:00,10:00,S,0,0,0
 C1,11:00,11:00,C1,1,0,0
@@ -93,4 +100,49 @@ F,S,2,600
 )__");
 }
 
-TEST(routing, lb_raptor) {}
+constexpr auto kGtfsDateRange = interval{sys_days{2026_y / February / 27},
+                                         sys_days{2026_y / February / 28}};
+
+constexpr auto kExpLbT = std::array<std::uint16_t, 16U>{
+    7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U, 7U};
+
+TEST(routing, lb_raptor) {
+  auto const tt = load_gtfs(lb_test_tt, kGtfsDateRange);
+  auto rtt = rt::create_rt_timetable(tt, sys_days{2026_y / February / 27});
+  auto const T = tt.find(location_id{"T", source_idx_t{}}).value();
+  auto const q =
+      query{.start_time_ = unixtime_t{sys_days{February / 27 / 2026}},
+            .destination_ = {{tt.locations_.location_id_to_idx_.at(
+                                  {"T", source_idx_t{0U}}),
+                              13_minutes, 0U}},
+            .td_dest_{{T,
+                       {{.valid_from_ = sys_days{2026_y / January / 27},
+                         .duration_ = 7_minutes,
+                         .transport_mode_id_ = 5},
+                        {.valid_from_ = sys_days{2026_y / January / 28},
+                         .duration_ = footpath::kMaxDuration,
+                         .transport_mode_id_ = 5}}}}};
+  auto state = raptor_state{};
+  auto location_round_lb =
+      vector_map<location_idx_t,
+                 std::array<std::uint16_t, kMaxTransfers + 2U>>{};
+
+  lb_raptor(tt, q, tt.fwd_search_lb_graph_[q.prf_idx_], nullptr, nullptr, state,
+            location_round_lb);
+
+  for (auto const [i, round_lb] : utl::enumerate(location_round_lb)) {
+    fmt::println("{}: {}", tt.get_default_name(location_idx_t{i}), round_lb);
+  }
+
+  ASSERT_LE(kMaxTransfers, std::uint8_t{14U});
+
+  auto const check = [](auto&& exp, auto&& act) {
+    for (auto const [e, a] :
+         std::views::zip(exp | std::views::take(kMaxTransfers + 2U),
+                         act | std::views::take(kMaxTransfers + 2U))) {
+      EXPECT_EQ(e, a);
+    }
+  };
+
+  check(kExpLbT, location_round_lb[T]);
+}

--- a/test/routing/lb_raptor_test.cc
+++ b/test/routing/lb_raptor_test.cc
@@ -92,3 +92,5 @@ from_stop_id,to_stop_id,transfer_type,min_transfer_time
 F,S,2,600
 )__");
 }
+
+TEST(routing, lb_raptor) {}

--- a/test/routing/lb_raptor_test.cc
+++ b/test/routing/lb_raptor_test.cc
@@ -146,45 +146,39 @@ TEST(routing, lb_raptor) {
                   {.valid_from_ = sys_days{2026_y / January / 28},
                    .duration_ = footpath::kMaxDuration,
                    .transport_mode_id_ = 5}}}}};
-  auto location_round_lb =
-      vector_map<location_idx_t,
-                 std::array<std::uint16_t, kMaxTransfers + 2U>>{};
-  auto station_mark = bitvec{};
-  auto prev_station_mark = bitvec{};
-  auto is_start = bitvec{};
+  auto state = lb_raptor_state{};
 
-  lb_raptor<direction::kForward>(tt, q, station_mark, prev_station_mark,
-                                 is_start, location_round_lb);
+  lb_raptor<direction::kForward>(tt, q, state);
 
   ASSERT_EQ(kMaxTransfers, 14U);
-  EXPECT_EQ(
-      kExpLbP,
-      location_round_lb[tt.find(location_id{"P", source_idx_t{}}).value()]);
-  EXPECT_EQ(
-      kExpLbF,
-      location_round_lb[tt.find(location_id{"F", source_idx_t{}}).value()]);
-  EXPECT_EQ(
-      kExpLbS,
-      location_round_lb[tt.find(location_id{"S", source_idx_t{}}).value()]);
-  EXPECT_EQ(
-      kExpLbB1,
-      location_round_lb[tt.find(location_id{"B1", source_idx_t{}}).value()]);
-  EXPECT_EQ(
-      kExpLbC1,
-      location_round_lb[tt.find(location_id{"C1", source_idx_t{}}).value()]);
-  EXPECT_EQ(
-      kExpLbC2,
-      location_round_lb[tt.find(location_id{"C2", source_idx_t{}}).value()]);
-  EXPECT_EQ(
-      kExpLbD1,
-      location_round_lb[tt.find(location_id{"D1", source_idx_t{}}).value()]);
-  EXPECT_EQ(
-      kExpLbD2,
-      location_round_lb[tt.find(location_id{"D2", source_idx_t{}}).value()]);
-  EXPECT_EQ(
-      kExpLbD3,
-      location_round_lb[tt.find(location_id{"D3", source_idx_t{}}).value()]);
-  EXPECT_EQ(
-      kExpLbT,
-      location_round_lb[tt.find(location_id{"T", source_idx_t{}}).value()]);
+  EXPECT_EQ(kExpLbP,
+            state.location_round_lb_[tt.find(location_id{"P", source_idx_t{}})
+                                         .value()]);
+  EXPECT_EQ(kExpLbF,
+            state.location_round_lb_[tt.find(location_id{"F", source_idx_t{}})
+                                         .value()]);
+  EXPECT_EQ(kExpLbS,
+            state.location_round_lb_[tt.find(location_id{"S", source_idx_t{}})
+                                         .value()]);
+  EXPECT_EQ(kExpLbB1,
+            state.location_round_lb_[tt.find(location_id{"B1", source_idx_t{}})
+                                         .value()]);
+  EXPECT_EQ(kExpLbC1,
+            state.location_round_lb_[tt.find(location_id{"C1", source_idx_t{}})
+                                         .value()]);
+  EXPECT_EQ(kExpLbC2,
+            state.location_round_lb_[tt.find(location_id{"C2", source_idx_t{}})
+                                         .value()]);
+  EXPECT_EQ(kExpLbD1,
+            state.location_round_lb_[tt.find(location_id{"D1", source_idx_t{}})
+                                         .value()]);
+  EXPECT_EQ(kExpLbD2,
+            state.location_round_lb_[tt.find(location_id{"D2", source_idx_t{}})
+                                         .value()]);
+  EXPECT_EQ(kExpLbD3,
+            state.location_round_lb_[tt.find(location_id{"D3", source_idx_t{}})
+                                         .value()]);
+  EXPECT_EQ(kExpLbT,
+            state.location_round_lb_[tt.find(location_id{"T", source_idx_t{}})
+                                         .value()]);
 }

--- a/test/routing/tb_test.cc
+++ b/test/routing/tb_test.cc
@@ -3,12 +3,12 @@
 #include "nigiri/loader/gtfs/load_timetable.h"
 #include "nigiri/loader/hrd/load_timetable.h"
 #include "nigiri/loader/init_finish.h"
-#include "nigiri/routing/raptor/debug.h"
 #include "nigiri/routing/search.h"
 #include "nigiri/routing/tb/preprocess.h"
 #include "nigiri/routing/tb/query_engine.h"
 
 #include "../loader/hrd/hrd_timetable.h"
+#include "../util.h"
 
 using namespace date;
 using namespace nigiri;
@@ -17,15 +17,9 @@ using namespace nigiri::loader;
 using namespace std::chrono_literals;
 using namespace nigiri::test_data::hrd_timetable;
 
-timetable load_gtfs(auto const& files) {
-  timetable tt;
-  tt.date_range_ = {date::sys_days{2021_y / March / 1},
-                    date::sys_days{2021_y / March / 8}};
-  register_special_stations(tt);
-  gtfs::load_timetable({}, source_idx_t{0}, files(), tt);
-  finalize(tt);
-  return tt;
-}
+constexpr auto kGtfsDateRange = interval{date::sys_days{2021_y / March / 1},
+                                         date::sys_days{2021_y / March / 8}};
+
 timetable load_hrd(auto const& files) {
   timetable tt;
   tt.date_range_ = full_period();
@@ -131,7 +125,7 @@ R1_THU,07:00:00,07:00:00,S2,1,0,0
 }
 
 TEST(tb_preprocess, no_transfer) {
-  auto const tt = load_gtfs(no_transfer_files);
+  auto const tt = load_gtfs(no_transfer_files, kGtfsDateRange);
   auto const tbd = tb::preprocess(tt, profile_idx_t{0});
   for (auto const transfers : tbd.segment_transfers_) {
     EXPECT_TRUE(transfers.empty());
@@ -174,7 +168,7 @@ R1_MON,13:00:00,13:00:00,S2,1,0,0
 }
 
 TEST(tb_preprocess, same_day_transfer) {
-  auto const tt = load_gtfs(same_day_transfer_files);
+  auto const tt = load_gtfs(same_day_transfer_files, kGtfsDateRange);
   auto const tbd = tb::preprocess(tt, profile_idx_t{0});
   auto const s = tbd.transport_first_segment_[transport_idx_t{0U}];
   ASSERT_EQ(1U, tbd.segment_transfers_[s].size());
@@ -204,7 +198,7 @@ leg 3: (S2, S2) [2021-03-01 13:00] -> (S2, S2) [2021-03-01 13:00]
 )";
 
 TEST(tb_query, same_day_transfer) {
-  auto const tt = load_gtfs(same_day_transfer_files);
+  auto const tt = load_gtfs(same_day_transfer_files, kGtfsDateRange);
   auto const tbd = tb::preprocess(tt, profile_idx_t{0});
   auto const results = tripbased_search(
       tt, tbd, "S0", "S2", unixtime_t{sys_days{February / 28 / 2021} + 23h});
@@ -249,7 +243,7 @@ R1_TUE,08:00:00,08:00:00,S2,1,0,0
 }
 
 TEST(tb_preprocess, next_day_transfer) {
-  auto const tt = load_gtfs(next_day_transfer_files);
+  auto const tt = load_gtfs(next_day_transfer_files, kGtfsDateRange);
   auto const tbd = tb::preprocess(tt, profile_idx_t{0});
   auto const s = tbd.transport_first_segment_[transport_idx_t{0U}];
   ASSERT_TRUE(tbd.segment_transfers_[s].size() == 1U);
@@ -297,7 +291,7 @@ R1_THU,07:00:00,07:00:00,S2,1,0,0
 }
 
 TEST(tb_preprocess, long_transfer) {
-  auto const tt = load_gtfs(long_transfer_files);
+  auto const tt = load_gtfs(long_transfer_files, kGtfsDateRange);
   auto const tbd = tb::preprocess(tt, profile_idx_t{0});
   auto const s = tbd.transport_first_segment_[transport_idx_t{0U}];
   ASSERT_TRUE(tbd.segment_transfers_[s].size() == 1U);
@@ -344,7 +338,7 @@ R1_WD,03:00:00,03:00:00,S2,1,0,0
 }
 
 TEST(tb_preprocess, weekday_transfer) {
-  auto const tt = load_gtfs(weekday_transfer_files);
+  auto const tt = load_gtfs(weekday_transfer_files, kGtfsDateRange);
   auto const tbd = tb::preprocess(tt, profile_idx_t{0});
   auto const s = tbd.transport_first_segment_[transport_idx_t{0U}];
   ASSERT_TRUE(tbd.segment_transfers_[s].size() == 1U);
@@ -391,7 +385,7 @@ R1_DLY,04:00:00,04:00:00,S2,1,0,0
 }
 
 TEST(tb_preprocess, daily_transfer) {
-  auto const tt = load_gtfs(daily_transfer_files);
+  auto const tt = load_gtfs(daily_transfer_files, kGtfsDateRange);
   auto const tbd = tb::preprocess(tt, profile_idx_t{0});
   auto const s = tbd.transport_first_segment_[transport_idx_t{0U}];
   ASSERT_TRUE(tbd.segment_transfers_[s].size() == 1U);
@@ -447,7 +441,7 @@ R0_MON1,09:00:00,09:00:00,S4,5,0,0
 }
 
 TEST(tb_preprocess, earlier_stop_transfer) {
-  auto const tt = load_gtfs(earlier_stop_transfer_files);
+  auto const tt = load_gtfs(earlier_stop_transfer_files, kGtfsDateRange);
   auto const tbd = tb::preprocess(tt, profile_idx_t{0});
   auto const s = tbd.transport_first_segment_[transport_idx_t{0U}] + 3U;
   ASSERT_TRUE(tbd.segment_transfers_[s].size() == 1U);
@@ -478,7 +472,7 @@ leg 3: (S2, S2) [2021-03-01 06:00] -> (S2, S2) [2021-03-01 06:00]
 )";
 
 TEST(tb_query, early_stop_transfer) {
-  auto const tt = load_gtfs(earlier_stop_transfer_files);
+  auto const tt = load_gtfs(earlier_stop_transfer_files, kGtfsDateRange);
   auto const tbd = tb::preprocess(tt, profile_idx_t{0});
   auto const results = tripbased_search(
       tt, tbd, "S3", "S2", unixtime_t{sys_days{February / 28 / 2021} + 23h});
@@ -487,7 +481,7 @@ TEST(tb_query, early_stop_transfer) {
 }
 
 TEST(tb_query, no_journey_possible) {
-  auto const tt = load_gtfs(earlier_stop_transfer_files);
+  auto const tt = load_gtfs(earlier_stop_transfer_files, kGtfsDateRange);
   auto const tbd = tb::preprocess(tt, profile_idx_t{0});
   auto const results = tripbased_search(
       tt, tbd, "S4", "S0", unixtime_t{sys_days{February / 28 / 2021} + 23h});
@@ -539,7 +533,7 @@ R0_MON1,06:00:00,06:00:00,S4,5,0,0
 }
 
 TEST(tb_preprocess, earlier_transport_transfer) {
-  auto const tt = load_gtfs(earlier_transport_transfer_files);
+  auto const tt = load_gtfs(earlier_transport_transfer_files, kGtfsDateRange);
   auto const tbd = tb::preprocess(tt, profile_idx_t{0});
   auto const s = tbd.transport_first_segment_[transport_idx_t{1U}];
   ASSERT_EQ(1U, tbd.segment_transfers_[s].size());
@@ -591,7 +585,7 @@ R1_MON,05:00:00,05:00:00,S3,2,0,0
 }
 
 TEST(tb_preprocess, uturn_transfer) {
-  auto const tt = load_gtfs(uturn_transfer_files);
+  auto const tt = load_gtfs(uturn_transfer_files, kGtfsDateRange);
   auto const tbd = tb::preprocess(tt, profile_idx_t{0});
   for (auto s = tb::segment_idx_t{1U}; s < tbd.segment_transfers_.size(); ++s) {
     EXPECT_TRUE(tbd.segment_transfers_[s].empty());
@@ -643,7 +637,7 @@ R1_MON,04:00:00,04:00:00,S2,1,0,0
 }
 
 TEST(tb_preprocess, unnecessary_transfer_1) {
-  auto const tt = load_gtfs(unnecessary_transfer_1_files);
+  auto const tt = load_gtfs(unnecessary_transfer_1_files, kGtfsDateRange);
   auto const tbd = tb::preprocess(tt, profile_idx_t{0});
   for (auto const transfers : tbd.segment_transfers_) {
     EXPECT_TRUE(transfers.empty());
@@ -693,7 +687,7 @@ R1_MON,03:10:00,03:10:00,S5,3,0,0
 }
 
 TEST(tb_preprocess, unnecessary_transfer_2) {
-  auto const tt = load_gtfs(unnecessary_transfer_2_files);
+  auto const tt = load_gtfs(unnecessary_transfer_2_files, kGtfsDateRange);
   auto const tbd = tb::preprocess(tt, profile_idx_t{0});
   auto const s = tbd.transport_first_segment_[transport_idx_t{0U}] + 1U;
   ASSERT_EQ(1U, tbd.segment_transfers_[s].size());
@@ -762,7 +756,7 @@ leg 3: (S3, S3) [2021-03-04 09:00] -> (S3, S3) [2021-03-04 09:00]
 )";
 
 TEST(tb_preprocess, early_train_journeys) {
-  auto const tt = load_gtfs(early_train_files);
+  auto const tt = load_gtfs(early_train_files, kGtfsDateRange);
   auto const tbd = tb::preprocess(tt, profile_idx_t{0});
   tbd.print(std::cout, tt);
   ASSERT_EQ("R1", tt.transport_name(transport_idx_t{1U}));
@@ -771,7 +765,7 @@ TEST(tb_preprocess, early_train_journeys) {
 }
 
 TEST(tb_query, early_train) {
-  auto const tt = load_gtfs(early_train_files);
+  auto const tt = load_gtfs(early_train_files, kGtfsDateRange);
   auto const tbd = tb::preprocess(tt, profile_idx_t{0});
   auto const results = tripbased_search(
       tt, tbd, "S1", "S3", unixtime_t{sys_days{March / 04 / 2021} + 5h});

--- a/test/util.h
+++ b/test/util.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "nigiri/loader/gtfs/load_timetable.h"
+#include "nigiri/loader/init_finish.h"
+#include "nigiri/timetable.h"
+
+nigiri::timetable load_gtfs(auto const& files,
+                            nigiri::interval<date::sys_days> const date_range) {
+  using namespace date;
+  nigiri::timetable tt;
+  tt.date_range_ = date_range;
+  nigiri::loader::register_special_stations(tt);
+  nigiri::loader::gtfs::load_timetable({}, nigiri::source_idx_t{0U}, files(),
+                                       tt);
+  nigiri::loader::finalize(tt);
+  return tt;
+}


### PR DESCRIPTION
 - creates lower bound adjacencies per location during timetable import
   - locations that are reachable without transfer and the respective minimal travel time
 - before doing the actual routing, run some sort of RAPTOR on the lb_adjacency graph to determine the minimal traveltime per number of transfers for each location from the destination

Overhead of LB adjacencies: 
- Calculating them during import takes 2.3 s on the DELFI GTFS
- the file size of the serialized timetable increases by ~30%

Running time [ms]  of LB RAPTOR for 1000 random Queries on the DELFI GTFS:
```
count  996.000000
mean   360.838353
std     54.876334
min    238.000000
25%    322.000000
50%    358.000000
75%    397.000000
max    615.000000
```
(I excluded 4 values = 7 ms. Probably, involved some island destination not connected to the rest of the timetable)

The main driver seems to be slow convergence. Regardless of the destination LB RAPTOR performs the maximum number of rounds. Even k = 15 yields minor improvements in travel time and therefore station marks are set until then. The current version takes transfer time into account and adds it to the travel time which helps a bit with convergence since it adds up and makes it harder for later rounds to trigger station marks with one-minute improvements or such.

## Evaluation on DELFI GTFS

Responses equal: **959/1000**

### Baseline
response_time
average: 394.78
max: 4,868
99 quantile: 2,549
90 quantile: 1,080
80 quantile: 615
50 quantile: 155
min: 0

### LB_RAPTOR
response_time
      average:        1,393.15
          max:        6,941
  99 quantile:        4,567
  90 quantile:        2,291
  80 quantile:        1,708
  50 quantile:        1,147
          min:            0