### PR TITLE
New config key : default_transfer_time to apply instead of hardcoded 2 minutes

### DIFF
--- a/include/nigiri/loader/gtfs/stop.h
+++ b/include/nigiri/loader/gtfs/stop.h
@@ -29,6 +29,7 @@ read_stops(source_idx_t,
            std::string_view stops_file_content,
            std::string_view transfers_file_content,
            unsigned link_stop_distance,
+           duration_t default_transfer_time = duration_t{2},
            script_runner const& = script_runner{});
 
 }  // namespace nigiri::loader::gtfs

--- a/include/nigiri/loader/loader_interface.h
+++ b/include/nigiri/loader/loader_interface.h
@@ -16,6 +16,7 @@ namespace nigiri::loader {
 
 struct loader_config {
   unsigned link_stop_distance_{100U};
+  duration_t default_transfer_time_{2};
   std::string default_tz_{};
   std::array<bool, kNumClasses> bikes_allowed_default_{};
   std::array<bool, kNumClasses> cars_allowed_default_{};

--- a/src/loader/gtfs/load_timetable.cc
+++ b/src/loader/gtfs/load_timetable.cc
@@ -95,9 +95,10 @@ void load_timetable(loader_config const& config,
   auto agencies =
       read_agencies(src, tt, i18n, timezones, load(kAgencyFile).data(),
                     config.default_tz_, user_script);
-  auto const [stops, seated_transfers, stops_accessible] = read_stops(
-      src, tt, i18n, timezones, load(kStopFile).data(),
-      load(kTransfersFile).data(), config.link_stop_distance_, user_script);
+  auto const [stops, seated_transfers, stops_accessible] =
+      read_stops(src, tt, i18n, timezones, load(kStopFile).data(),
+                 load(kTransfersFile).data(), config.link_stop_distance_,
+                 config.default_transfer_time_, user_script);
   add_stop_groups(tt, load(kStopGroupElementsFile).data(), stops);
   auto const routes =
       read_routes(src, tt, i18n, timezones, agencies, load(kRoutesFile).data(),

--- a/src/loader/gtfs/stop.cc
+++ b/src/loader/gtfs/stop.cc
@@ -212,6 +212,7 @@ read_stops(source_idx_t const src,
            std::string_view stops_file_content,
            std::string_view transfers_file_content,
            unsigned link_stop_distance,
+           duration_t const default_transfer_time,
            script_runner const& r) {
   auto const timer = scoped_timer{"gtfs.loader.stops"};
 
@@ -325,7 +326,7 @@ read_stops(source_idx_t const src,
         location_idx_t::invalid(),
         s->timezone_.empty() ? timezone_idx_t::invalid()
                              : get_tz_idx(tt, timezones, s->timezone_),
-        s->transfer_time_.value_or(2_minutes),
+        s->transfer_time_.value_or(default_transfer_time),
         timezones};
     if (process_location(r, loc)) {
       locations.emplace(id, s->location_ = register_location(tt, loc));

--- a/src/loader/netex/load_timetable.cc
+++ b/src/loader/netex/load_timetable.cc
@@ -1365,7 +1365,7 @@ void load_timetable(loader_config const& config,
                         stop->parent_ != nullptr ? stop->parent_->location_
                                                  : location_idx_t::invalid(),
                         tz,
-                        2_minutes,
+                        config.default_transfer_time_,
                         tz_map};
       if (process_location(r, s)) {
         stop->location_ = register_location(tt, s);
@@ -1797,7 +1797,8 @@ void load_timetable(loader_config const& config,
           auto const dist = std::sqrt(geo::approx_squared_distance(
               pos, neighbor_pos, dist_lng_degrees));
           auto const duration = duration_t{std::max(
-              2, static_cast<int>(std::ceil((dist / kWalkSpeed) / 60.0)))};
+              static_cast<int>(config.default_transfer_time_.count()),
+              static_cast<int>(std::ceil((dist / kWalkSpeed) / 60.0)))};
           metas[get_new_location(l)].emplace_back(neighbor, duration);
         }
       },


### PR DESCRIPTION
Hello,

The default transfer time used when transfers.txt provides no min_transfer_time is hardcoded to 2 minutes in the GTFS stop loader (stop.cc:329).

This is a proposal to add a config key to make this duration configurable.

Linked to : https://github.com/motis-project/motis/pull/1457