### PR TITLE
assume sorted offsets for performance

### DIFF
--- a/include/nigiri/routing/search.h
+++ b/include/nigiri/routing/search.h
@@ -195,8 +195,6 @@ struct search {
                    q_.transfer_time_settings_,
                    algo_state)},
         timeout_(timeout) {
-    utl::sort(q_.start_);
-    utl::sort(q_.destination_);
     q_.sanitize(tt);
   }
 

--- a/src/routing/direct.cc
+++ b/src/routing/direct.cc
@@ -47,12 +47,12 @@ std::optional<journey::leg> lookup_offset(location_idx_t const loc,
     return std::optional{make_leg(td->first, td->second.transport_mode_id_)};
   }
 
-  // Search for shortest offset.
+  // Search for shortest offset, assuming offsets are sorted ASC
   auto best = std::optional<offset>{};
   for (auto const& o : offsets) {
-    if (o.target() == loc &&
-        (!best.has_value() || o.duration() < best->duration())) {
+    if (o.target() == loc) {
       best = o;
+      break;
     }
   }
 

--- a/src/routing/query.cc
+++ b/src/routing/query.cc
@@ -62,6 +62,8 @@ void query::sanitize(timetable const& tt) {
               "intermodal start is incompatible with use_start_footpaths");
   sanitize_query(*this);
   sanitize_via_stops(tt, *this);
+  utl::sort(start_);
+  utl::sort(destination_);
 }
 
 }  // namespace nigiri::routing


### PR DESCRIPTION
not sure why in rraptor we sort offsets and in pong we don't (?). but I propose to always sort them over in motis.

The lookup_offset loop is becoming quite expensive in certain cases (dense city with lots of direct routes and lots of offsets). Even with this tweak it can still consume 3s for the default `numLegAlternatives=3` (e.g. https://test.motis-project.org/?time=2026-07-22T10%3A54%3A00.000Z&fromPlace=48.84103907668603%2C2.316604555818344&toPlace=48.87615362084247%2C2.3606689742726985&withFares=true&numLegAlternatives=3&joinInterlinedLegs=false&preTransitModes=WALK%2CRENTAL&postTransitModes=WALK%2CRENTAL&directModes=WALK%2CRENTAL&preTransitRentalFormFactors=SCOOTER_STANDING%2CBICYCLE&postTransitRentalFormFactors=SCOOTER_STANDING%2CBICYCLE&directRentalFormFactors=SCOOTER_STANDING%2CBICYCLE&maxMatchingDistance=250&maxPreTransitTime=1800&maxPostTransitTime=1800&maxDirectTime=3600).